### PR TITLE
Add kitty graphics renderer

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules
 build
 .tsimp
+.github

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 Better image component for [Ink](https://github.com/vadimdemedes/ink) CLI/TUI applications.
 
-Display images in your terminal with automatic protocol detection and graceful fallbacks. Supports ASCII, Braille patterns, Unicode half-blocks, Sixel graphics, and iTerm2 inline images.
+Display images in your terminal with automatic protocol detection and graceful fallbacks. Supports Sixel, Kitty image protocol, iTerm2 inline images, ASCII art, and more!
 
-<img width="1919" height="765" alt="Screenshot 2025-09-07 160615" src="https://github.com/user-attachments/assets/0be5be69-043a-446a-aa8a-7d138919113c" />
+[![npm](https://img.shields.io/npm/v/ink-picture?style=flat-square)](https://www.npmjs.com/package/ink-picture)
+![MIT License](https://img.shields.io/github/license/endernoke/ink-picture?style=flat-square)
+[![downloads](https://img.shields.io/npm/dm/ink-picture?style=flat-square)](https://www.npmjs.com/package/ink-picture)
+
+<img width="1106" height="519" alt="image" src="https://github.com/user-attachments/assets/caac83df-eb35-4b65-bcb1-0a89e889ea83" />
 
 ## Who's using ink-picture?
 
@@ -58,7 +62,7 @@ Main component with automatic protocol detection and fallback.
 - `width?` (number) - Width in terminal cells
 - `height?` (number) - Height in terminal cells
 - `alt?` (string) - Alternative text for loading/error states
-- `protocol?` (string) - Force specific protocol: `"ascii" | "braille" | "halfBlock" | "sixel" | "iterm2"` (`sixel` and `iterm2` are experimental, see [Important Notes](#important-notes--caveats))
+- `protocol?` (string) - Force specific protocol: `"ascii" | "braille" | "halfBlock" | "sixel" | "iterm2" | "kitty"`
 
 #### Protocols
 
@@ -67,8 +71,9 @@ The component automatically selects the best available protocol:
 1. **Half-block** (`halfBlock`) - Color rendering with Unicode half-blocks (▄). Requires color + Unicode support.
 2. **Braille** (`braille`) - High-resolution monochrome using Braille patterns. Requires Unicode support.
 3. **ASCII** (`ascii`) - Character-based art. Works in all terminals (fallback).
-4. **Sixel** (`sixel`) - True color bitmap graphics. Requires Sixel support (experimental).
-5. **iTerm2** (`iterm2`) - True color images in iTerm2-compatible terminals (experimental).
+4. **Sixel** (`sixel`) - True color bitmap graphics in [Sixel-compatible terminals](https://www.arewesixelyet.com/).
+5. **iTerm2** (`iterm2`) - True color images in terminals that implements the [iTerm2 inline images protocol](https://iterm2.com/documentation-images.html).
+6. **Kitty** (`kitty`) - True color images in terminals that support the [Kitty terminal graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/).
 
 ### `<TerminalInfoProvider>`
 
@@ -100,22 +105,24 @@ import {
 
 ## Important Notes & Caveats
 
-### Sixel and iTerm2 Renderers (Experimental)
+### High quality renderers
 
-The Sixel and iTerm2 renderers provide the highest quality but come with important limitations:
+The Kitty, Sixel, and iTerm2 renderers provide the highest image quality but may not work perfectly in all environments. This is because they rely on hacky side effects to display and clear images.
 
-⚠️ **Experimental Warning:** These components bypasses React/Ink's normal rendering pipeline and writes directly to the terminal. You may experience:
+> [!WARNING]
+> These components bypasses React/Ink's normal rendering pipeline and writes directly to the terminal.
+
+You may experience:
 
 - Rendering flicker during updates
-- Cursor positioning issues
-- Cleanup problems on component unmount
-- Images may be gone after app termination
+- Images may be wiped from the terminal after app termination
+
+These issues are difficult/infeasible to fix and I will not be addressing them in the near future. If you know a solution, please open an issue or PR.
 
 ### General Considerations
 
 - Images are fetched and processed asynchronously
 - Large images are automatically resized to fit terminal constraints
-- Remote images require network access
 - Terminal capability detection happens once per session
 
 ## Examples
@@ -149,6 +156,45 @@ The Sixel and iTerm2 renderers provide the highest quality but come with importa
 </Box>;
 ```
 
+## Choosing the right protocol
+
+> Devs using this library are highly encouraged to provide a configuration option to select the image protocol that works best for their users.
+
+If you use `ink-picture` in your project, feel free to link to this section in your documentation.
+
+Please read if you use a project that uses `ink-picture`.
+
+`ink-picture` should work out-of-the-box in most modern terminal emulators. Yet, not all terminals support all image protocols.
+
+Use the table below as a reference to check which protocol to use for your terminal. You might also want to install a better terminal emulator for best experience.
+
+✅ = Fully supported  
+⚠️ = Partially supported (works but may have issues/caveats)
+❌ = Not supported
+
+| Terminal Emulator | kitty graphics | iTerm2 inline images |
+| ----------------- | -------------- | -------------------- |
+| Kitty             | ✅             | ❌                   |
+| iTerm2            | ❌             | ✅                   |
+| WezTerm           | ✅             | ✅                   |
+| Konsole           | ✅             | ⚠️                   |
+| Ghostty           | ✅             | ❌                   |
+| Warp              | ⚠️             | ❌                   |
+| Rio               | ❌             | ✅                   |
+| Wayst             | ⚠️             | ❌                   |
+
+Please refer to [Are We Sixel Yet?](https://www.arewesixelyet.com/) for a comprehensive list of terminals that support Sixel graphics.
+
+> If your terminal supports any of the above protocols but is not listed here, please open an issue or PR to update the table.
+
+Generally, it is recommended to use the kitty protocol if it is fully supported, as it provides near-perfect performance, without any flickers or artifacts.
+
+Otherwise, the performance of sixel and iterm2 protocols are practically the same, so use whichever your terminal supports.
+
+If not provided with a explicit protocol, `ink-picture` will automatically select the best available protocol from the fallbacks (`halfBlock`, `braille`, `ascii`) based on detected terminal capabilities.
+
+See the [protocols section](#protocols) for more details.
+
 ## Contributing
 
 Contributions are welcome! To contribute:
@@ -160,3 +206,8 @@ Contributions are welcome! To contribute:
 5. Make your changes
 6. Run tests: `npm test`
 7. Open a pull request
+
+## License
+
+MIT License, see [LICENSE](LICENSE).
+)

--- a/example/image.tsx
+++ b/example/image.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Image from "../src/components/image/index.js";
-import { Text, Box, render, useInput } from "ink";
+import { Text, Box, render, useInput, useApp } from "ink";
 import {
   TerminalInfoProvider,
   useTerminalCapabilities,
@@ -140,9 +140,10 @@ function ProtocolDemo({ config }: { config: ProtocolConfig }) {
 }
 
 function ProtocolShowcase() {
+  const { exit } = useApp();
   useInput((input, key) => {
     if (key.ctrl && input === "c") {
-      process.exit();
+      exit();
     }
   });
 

--- a/example/image.tsx
+++ b/example/image.tsx
@@ -77,6 +77,18 @@ const protocols: ProtocolConfig[] = [
         : "No iTerm2 graphics support detected",
     }),
   },
+  {
+    name: "Kitty Graphics",
+    protocol: "kitty",
+    description: "True color bitmap (proprietary)",
+    requirements: "Kitty-compatible terminal",
+    getSupportStatus: (caps) => ({
+      supported: caps?.supportsKittyGraphics,
+      reason: caps?.supportsKittyGraphics
+        ? "Fully supported"
+        : "No Kitty graphics support detected",
+    }),
+  },
 ];
 
 function ProtocolDemo({ config }: { config: ProtocolConfig }) {
@@ -146,13 +158,13 @@ function ProtocolShowcase() {
 
         <Box flexDirection="column" marginBottom={1}>
           <Box flexDirection="row">
-            {protocols.slice(0, 3).map((config) => (
-              <ProtocolDemo key={config.protocol} config={config} />
+            {protocols.slice(0, 3).map((config, index) => (
+              <ProtocolDemo key={index} config={config} />
             ))}
           </Box>
           <Box flexDirection="row">
-            {protocols.slice(3).map((config) => (
-              <ProtocolDemo key={config.protocol} config={config} />
+            {protocols.slice(3).map((config, index) => (
+              <ProtocolDemo key={index} config={config} />
             ))}
           </Box>
         </Box>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,12 @@
         "node-fetch": "^3.3.2",
         "sharp": "^0.34.3",
         "sixel": "^0.16.0",
-        "supports-color": "^10.2.0",
-        "tmp": "^0.2.5"
+        "supports-color": "^10.2.0"
       },
       "devDependencies": {
         "@types/node": "^24.3.0",
         "@types/node-fetch": "^2.6.13",
         "@types/react": "^19.1.12",
-        "@types/tmp": "^0.2.6",
         "ava": "^6.4.1",
         "eslint": "^9.33.0",
         "eslint-config-prettier": "^10.1.8",
@@ -926,13 +924,6 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@types/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.40.0",
@@ -8576,15 +8567,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ink-picture",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ink-picture",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^7.1.0",
@@ -16,12 +16,14 @@
         "node-fetch": "^3.3.2",
         "sharp": "^0.34.3",
         "sixel": "^0.16.0",
-        "supports-color": "^10.2.0"
+        "supports-color": "^10.2.0",
+        "tmp": "^0.2.5"
       },
       "devDependencies": {
         "@types/node": "^24.3.0",
         "@types/node-fetch": "^2.6.13",
         "@types/react": "^19.1.12",
+        "@types/tmp": "^0.2.6",
         "ava": "^6.4.1",
         "eslint": "^9.33.0",
         "eslint-config-prettier": "^10.1.8",
@@ -924,6 +926,13 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.40.0",
@@ -8567,6 +8576,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ink-picture",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Better image component for Ink CLI/TUIs",
   "license": "MIT",
   "repository": "https://github.com/endernoke/ink-picture",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/node": "^24.3.0",
     "@types/node-fetch": "^2.6.13",
     "@types/react": "^19.1.12",
-    "@types/tmp": "^0.2.6",
     "ava": "^6.4.1",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
@@ -91,7 +90,6 @@
     "node-fetch": "^3.3.2",
     "sharp": "^0.34.3",
     "sixel": "^0.16.0",
-    "supports-color": "^10.2.0",
-    "tmp": "^0.2.5"
+    "supports-color": "^10.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/node": "^24.3.0",
     "@types/node-fetch": "^2.6.13",
     "@types/react": "^19.1.12",
+    "@types/tmp": "^0.2.6",
     "ava": "^6.4.1",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
@@ -90,6 +91,7 @@
     "node-fetch": "^3.3.2",
     "sharp": "^0.34.3",
     "sixel": "^0.16.0",
-    "supports-color": "^10.2.0"
+    "supports-color": "^10.2.0",
+    "tmp": "^0.2.5"
   }
 }

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -134,7 +134,8 @@ function ITerm2Image(props: ImageProps) {
     props.src,
     props.width,
     props.height,
-    componentPosition,
+    componentPosition?.width,
+    componentPosition?.height,
     terminalDimensions,
   ]);
 
@@ -191,21 +192,14 @@ function ITerm2Image(props: ImageProps) {
       | { row: number; col: number; width: number; height: number }
       | undefined = undefined;
     const renderTimeout = setTimeout(() => {
+      stdout.write("\x1b7"); // Save cursor position
       stdout.write(
         cursorUp(componentPosition.appHeight - componentPosition.row),
       );
       stdout.write("\r");
       stdout.write(cursorForward(componentPosition.col));
       stdout.write(imageOutput);
-      stdout.write(
-        cursorDown(
-          componentPosition.appHeight -
-            componentPosition.row -
-            (actualSizeInCells?.height ?? 0) +
-            1,
-        ),
-      );
-      stdout.write("\r");
+      stdout.write("\x1b8"); // Restore cursor position
 
       previousRenderBoundingBox = {
         row: stdout.rows - componentPosition.appHeight + componentPosition.row,
@@ -225,6 +219,7 @@ function ITerm2Image(props: ImageProps) {
       // If we never rendered the image, nothing to clean up
       if (!previousRenderBoundingBox) return;
 
+      stdout.write("\x1b7"); // Save cursor position
       stdout.write(
         cursorUp(componentPosition.appHeight - componentPosition.row),
       );
@@ -241,15 +236,7 @@ function ITerm2Image(props: ImageProps) {
         stdout.write("\n");
         // }
       }
-      // Restore cursor position
-      stdout.write(
-        cursorDown(
-          componentPosition.appHeight -
-            componentPosition.row -
-            previousRenderBoundingBox.height,
-        ),
-      );
-      stdout.write("\r");
+      stdout.write("\x1b8"); // Restore cursor position
     };
     // }, [imageOutput, ...Object.values(componentPosition)]);
   });

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { Box, Text, Newline, useStdout, type DOMElement } from "ink";
 // import { backgroundContext } from "ink";
 import AnsiEscapes from "ansi-escapes";
@@ -118,10 +118,10 @@ function ITerm2Image(props: ImageProps) {
         .png() // iTerm2 expects a FILE, not raw pixel data
         .toBuffer({ resolveWithObject: true });
       setActualSizeInCells({
-        width: Math.floor(
+        width: Math.ceil(
           resizedImage.info.width / terminalDimensions.cellWidth,
         ),
-        height: Math.floor(
+        height: Math.ceil(
           resizedImage.info.height / terminalDimensions.cellHeight,
         ),
       });
@@ -168,7 +168,7 @@ function ITerm2Image(props: ImageProps) {
    *
    * TODO: This may change when Ink implements incremental rendering
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!imageOutput) return;
     if (!componentPosition) return;
     if (
@@ -207,7 +207,7 @@ function ITerm2Image(props: ImageProps) {
         width: actualSizeInCells!.width,
         height: actualSizeInCells!.height,
       };
-    }, 50); // Delay to allow Ink/terminal to finish its render
+    }, 100); // Delay to allow Ink/terminal to finish its render
 
     return () => {
       process.removeListener("exit", onExit);

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -298,13 +298,4 @@ function cursorUp(count: number = 1) {
   return "\x1b[" + count + "A";
 }
 
-/**
- * Moves cursor down by specified number of rows.
- * @param count - Number of rows to move down (default: 1)
- * @returns ANSI escape sequence string
- */
-function cursorDown(count: number = 1) {
-  return "\x1b[" + count + "B";
-}
-
 export default ITerm2Image;

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -9,7 +9,6 @@ import {
 import { type ImageProps } from "./protocol.js";
 import { fetchImage, calculateImageSize } from "../../utils/image.js";
 import generateKittyId from "../../utils/generateKittyId.js";
-import tmp from "tmp";
 
 /**
  * Kitty Image Rendering Component
@@ -58,11 +57,6 @@ function KittyImage(props: ImageProps) {
   const componentPosition = usePosition(containerRef);
   const terminalDimensions = useTerminalDimensions();
   const terminalCapabilities = useTerminalCapabilities();
-  const [actualSizeInCells, setActualSizeInCells] = useState<{
-    width: number;
-    height: number;
-  } | null>(null);
-  const shouldCleanupRef = useRef<boolean>(true);
 
   // Detect support and notify parent
   useEffect(() => {
@@ -113,14 +107,6 @@ function KittyImage(props: ImageProps) {
       });
 
       const resizedImage = image.resize(width, height);
-      const resizedMetadata = await resizedImage.metadata();
-
-      setActualSizeInCells({
-        width: Math.ceil(resizedMetadata.width / terminalDimensions.cellWidth),
-        height: Math.ceil(
-          resizedMetadata.height / terminalDimensions.cellHeight,
-        ),
-      });
 
       try {
         const imageId = generateKittyId();
@@ -213,7 +199,6 @@ function KittyImage(props: ImageProps) {
   useEffect(() => {
     return () => {
       if (!imageId) return;
-      if (!shouldCleanupRef.current) return;
 
       // a=d: delete image; d=I: remove image data from storage; i=image-id
       stdout.write(`\x1b_Ga=d,d=I,i=${imageId}\x1b\\`);
@@ -257,15 +242,6 @@ function cursorForward(count: number = 1) {
  */
 function cursorUp(count: number = 1) {
   return "\x1b[" + count + "A";
-}
-
-/**
- * Moves cursor down by specified number of rows.
- * @param count - Number of rows to move down (default: 1)
- * @returns ANSI escape sequence string
- */
-function cursorDown(count: number = 1) {
-  return "\x1b[" + count + "B";
 }
 
 export default KittyImage;

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -116,8 +116,8 @@ function KittyImage(props: ImageProps) {
       const resizedMetadata = await resizedImage.metadata();
 
       setActualSizeInCells({
-        width: Math.floor(resizedMetadata.width / terminalDimensions.cellWidth),
-        height: Math.floor(
+        width: Math.ceil(resizedMetadata.width / terminalDimensions.cellWidth),
+        height: Math.ceil(
           resizedMetadata.height / terminalDimensions.cellHeight,
         ),
       });

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -1,0 +1,265 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Box, Text, Newline, useStdout, type DOMElement } from "ink";
+// import { backgroundContext } from "ink";
+import usePosition from "../../hooks/usePosition.js";
+import {
+  useTerminalDimensions,
+  useTerminalCapabilities,
+} from "../../context/TerminalInfo.js";
+import { type ImageProps } from "./protocol.js";
+import sharp from "sharp";
+import { fetchImage, calculateImageSize } from "../../utils/image.js";
+import generateKittyId from "../../utils/generateKittyId.js";
+import tmp from "tmp";
+import { image } from "ansi-escapes";
+import fs from "fs";
+
+/**
+ * Kitty Image Rendering Component
+ *
+ * Displays images using the Kitty terminal graphics protocol, providing the highest quality
+ * image rendering in supported terminals. Kitty is a bitmap graphics format that
+ * can display true color images at full resolution.
+ *
+ * Features:
+ * - Highest quality image rendering (true color, full resolution)
+ * - Supports all image formats
+ * - Requires specific terminal support (VT340+, xterm, iTerm2, etc.)
+ * - Direct pixel-to-pixel rendering
+ *
+ * Technical Details:
+ * - Uses the Kitty graphics protocol
+ * - Renders directly to terminal using escape sequences
+ * - Bypasses Ink's normal rendering pipeline for control over image position
+ * - Requires careful cursor management and cleanup
+ *
+ * **EXPERIMENTAL COMPONENT WARNING:**
+ * This component does not follow React/Ink's normal rendering lifecycle.
+ * It implements custom rendering logic that writes directly to the terminal.
+ * While designed to be as React-compatible as possible, you may experience:
+ * - Rendering flicker
+ * - Cursor positioning issues
+ * - Cleanup problems on component unmount
+ *
+ * How it works:
+ * 1. A Box component reserves space in the layout
+ * 2. Image is fetched and converted to Kitty format
+ * 3. useEffect hook renders image directly to terminal after each Ink render
+ * 4. Previous image is cleared before rendering new content
+ * 5. Cleanup occurs on component unmount or re-render
+ * 6. Cleanup will not be performed when application terminates (so the rendered image is preserved in its location)
+ *
+ * @param props - Image rendering properties
+ * @returns JSX element that manages Kitty image display
+ */
+function KittyImage(props: ImageProps) {
+  const [imageId, setImageId] = useState<number | undefined>(undefined);
+  const [hasError, setHasError] = useState<boolean>(false);
+  const { stdout } = useStdout();
+  const containerRef = useRef<DOMElement | null>(null);
+  const componentPosition = usePosition(containerRef);
+  const terminalDimensions = useTerminalDimensions();
+  const terminalCapabilities = useTerminalCapabilities();
+  const [actualSizeInCells, setActualSizeInCells] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  const shouldCleanupRef = useRef<boolean>(true);
+
+  // Detect support and notify parent
+  useEffect(() => {
+    if (!terminalCapabilities) return;
+
+    // Kitty rendering requires explicit kitty graphics support
+    const isSupported = terminalCapabilities.supportsKittyGraphics;
+    props.onSupportDetected?.(isSupported);
+  }, [terminalCapabilities, props.onSupportDetected]);
+
+  // TODO: If we upgrade to Ink 6 we will need to deal with Box background colors when rendering/cleaning up
+  // const inheritedBackgroundColor = useContext(backgroundContext);
+
+  /**
+   * Main effect for image processing and Kitty conversion.
+   *
+   * This effect:
+   * 1. Fetches and processes the source image
+   * 2. Calculates appropriate sizing based on terminal dimensions
+   * 3. Resizes image to fit within the component's allocated space
+   * 4. Ensures alpha channel is present (required by node-kitty)
+   * 5. Converts processed image data to Kitty format
+   * 6. Tracks actual size in terminal cells for cleanup purposes
+   */
+  useEffect(() => {
+    const generateImageOutput = async () => {
+      if (!componentPosition) return;
+      if (!terminalDimensions) return;
+
+      const image = await fetchImage(props.src);
+      if (!image) {
+        setHasError(true);
+        return;
+      }
+      setHasError(false);
+
+      const metadata = await image.metadata();
+
+      const { width: maxWidth, height: maxHeight } = componentPosition;
+      const { width, height } = calculateImageSize({
+        maxWidth: maxWidth * terminalDimensions.cellWidth,
+        maxHeight: maxHeight * terminalDimensions.cellHeight,
+        originalAspectRatio: metadata.width / metadata.height,
+        specifiedWidth: props.width
+          ? props.width * terminalDimensions.cellWidth
+          : undefined,
+        specifiedHeight: props.height
+          ? props.height * terminalDimensions.cellHeight
+          : undefined,
+      });
+
+      const resizedImage = image.resize(width, height);
+      const resizedMetadata = await resizedImage.metadata();
+
+      setActualSizeInCells({
+        width: Math.floor(resizedMetadata.width / terminalDimensions.cellWidth),
+        height: Math.floor(
+          resizedMetadata.height / terminalDimensions.cellHeight,
+        ),
+      });
+
+      try {
+        const tmpImageFile = tmp.fileSync({
+          prefix: "ink-picture.tty-graphics-protocol.",
+          postfix: ".png",
+        });
+        await resizedImage.png().toFile(tmpImageFile.name);
+
+        // Transfer pixel data to terminal
+        const imageId = generateKittyId();
+        stdout.write(
+          `\x1b_Gf=100,t=t,i=${imageId},q=2;${Buffer.from(tmpImageFile.name).toString("base64")}\x1b\\`,
+        );
+        setImageId(imageId);
+      } catch {
+        setHasError(true);
+        return;
+      }
+    };
+    generateImageOutput();
+  }, [
+    props.src,
+    props.width,
+    props.height,
+    componentPosition?.width,
+    componentPosition?.height,
+    terminalDimensions,
+  ]);
+
+  /**
+   * Critical rendering effect for Kitty image display.
+   *
+   * This effect runs after every re-render to display the Kitty image because
+   * Ink overwrites the terminal content with each render cycle. This is a
+   * necessary workaround for the current Ink architecture.
+   *
+   * Process:
+   * 1. Validates that image and position data are available
+   * 2. Checks if the image would be visible within terminal bounds
+   * 3. Sets up process exit handlers for cleanup
+   * 4. Positions cursor to the correct location
+   * 5. Writes Kitty data directly to stdout
+   * 6. Restores cursor position
+   * 7. Returns cleanup function for previous render cleanup
+   *
+   * Cursor Management:
+   * - Moves cursor up to component position
+   * - Moves cursor right to correct column
+   * - Writes image data
+   * - Moves cursor back down to original position
+   *
+   * Cleanup Strategy:
+   * - Tracks previous render bounding box
+   * - Clears previous image by writing spaces
+   * - Handles process exit gracefully
+   *
+   * TODO: This may change when Ink implements incremental rendering
+   */
+  useEffect(() => {
+    if (!imageId) return;
+    if (!componentPosition) return;
+
+    stdout.write(cursorUp(componentPosition.appHeight - componentPosition.row));
+    stdout.write("\r");
+    stdout.write(cursorForward(componentPosition.col));
+
+    const placementId = 1; // We only have one image per component instance
+    stdout.write(`\x1b_Ga=p,i=${imageId},p=${placementId},C=1,q=2\x1b\\`);
+
+    stdout.write(
+      cursorDown(componentPosition.appHeight - componentPosition.row),
+    );
+    stdout.write("\r");
+
+    // We do not clean up on rerenders
+    // because kitty manages replacing
+    // images with the same placement ID
+  });
+
+  // Cleanup effect to remove Kitty image on unmount or image change only
+  useEffect(() => {
+    return () => {
+      if (!imageId) return;
+      if (!shouldCleanupRef.current) return;
+
+      stdout.write(`\x1b_Ga=d,d=I,i=${imageId}\x1b\\`);
+    };
+  }, [imageId, stdout]);
+
+  return (
+    <Box ref={containerRef} flexDirection="column" flexGrow={1}>
+      {imageId ? (
+        <Text color="gray" wrap="wrap">
+          {props.alt || "Loading..."}
+        </Text>
+      ) : (
+        <Box flexDirection="column" alignItems="center" justifyContent="center">
+          {hasError && (
+            <Text color="red">
+              X<Newline />
+              Load failed
+            </Text>
+          )}
+          <Text color="gray">{props.alt || "Loading..."}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Moves cursor forward (right) by specified number of columns.
+ * @param count - Number of columns to move forward (default: 1)
+ * @returns ANSI escape sequence string
+ */
+function cursorForward(count: number = 1) {
+  return "\x1b[" + count + "C";
+}
+
+/**
+ * Moves cursor up by specified number of rows.
+ * @param count - Number of rows to move up (default: 1)
+ * @returns ANSI escape sequence string
+ */
+function cursorUp(count: number = 1) {
+  return "\x1b[" + count + "A";
+}
+
+/**
+ * Moves cursor down by specified number of rows.
+ * @param count - Number of rows to move down (default: 1)
+ * @returns ANSI escape sequence string
+ */
+function cursorDown(count: number = 1) {
+  return "\x1b[" + count + "B";
+}
+
+export default KittyImage;

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -135,7 +135,8 @@ function SixelImage(props: ImageProps) {
     props.src,
     props.width,
     props.height,
-    componentPosition,
+    componentPosition?.width,
+    componentPosition?.height,
     terminalDimensions,
   ]);
 
@@ -192,16 +193,14 @@ function SixelImage(props: ImageProps) {
       | { row: number; col: number; width: number; height: number }
       | undefined = undefined;
     const renderTimeout = setTimeout(() => {
+      stdout.write("\x1b7"); // Save cursor position
       stdout.write(
         cursorUp(componentPosition.appHeight - componentPosition.row),
       );
       stdout.write("\r");
       stdout.write(cursorForward(componentPosition.col));
       stdout.write(imageOutput);
-      stdout.write(
-        cursorDown(componentPosition.appHeight - componentPosition.row),
-      );
-      stdout.write("\r");
+      stdout.write("\x1b8"); // Restore cursor position
 
       previousRenderBoundingBox = {
         row: stdout.rows - componentPosition.appHeight + componentPosition.row,
@@ -221,6 +220,7 @@ function SixelImage(props: ImageProps) {
       // If we never rendered the image, nothing to clean up
       if (!previousRenderBoundingBox) return;
 
+      stdout.write("\x1b7"); // Save cursor position
       stdout.write(
         cursorUp(componentPosition.appHeight - componentPosition.row),
       );
@@ -237,15 +237,7 @@ function SixelImage(props: ImageProps) {
         stdout.write("\n");
         // }
       }
-      // Restore cursor position
-      stdout.write(
-        cursorDown(
-          componentPosition.appHeight -
-            componentPosition.row -
-            previousRenderBoundingBox.height,
-        ),
-      );
-      stdout.write("\r");
+      stdout.write("\x1b8"); // Restore cursor position
     };
     // }, [imageOutput, ...Object.values(componentPosition)]);
   });

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -301,13 +301,4 @@ function cursorUp(count: number = 1) {
   return "\x1b[" + count + "A";
 }
 
-/**
- * Moves cursor down by specified number of rows.
- * @param count - Number of rows to move down (default: 1)
- * @returns ANSI escape sequence string
- */
-function cursorDown(count: number = 1) {
-  return "\x1b[" + count + "B";
-}
-
 export default SixelImage;

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { Box, Text, Newline, useStdout, type DOMElement } from "ink";
 // import { backgroundContext } from "ink";
 import { image2sixel } from "sixel";
@@ -119,10 +119,10 @@ function SixelImage(props: ImageProps) {
         .raw()
         .toBuffer({ resolveWithObject: true });
       setActualSizeInCells({
-        width: Math.floor(
+        width: Math.ceil(
           resizedImage.info.width / terminalDimensions.cellWidth,
         ),
-        height: Math.floor(
+        height: Math.ceil(
           resizedImage.info.height / terminalDimensions.cellHeight,
         ),
       });
@@ -169,7 +169,7 @@ function SixelImage(props: ImageProps) {
    *
    * TODO: This may change when Ink implements incremental rendering
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!imageOutput) return;
     if (!componentPosition) return;
     if (
@@ -208,7 +208,7 @@ function SixelImage(props: ImageProps) {
         width: actualSizeInCells!.width,
         height: actualSizeInCells!.height,
       };
-    }, 50); // Delay to allow Ink/terminal to finish its render
+    }, 100); // Delay to allow Ink/terminal to finish its render
 
     return () => {
       process.removeListener("exit", onExit);

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -5,6 +5,7 @@ import HalfBlockImage from "./HalfBlock.js";
 import BrailleImage from "./Braille.js";
 import SixelImage from "./Sixel.js";
 import ITerm2Image from "./ITerm2.js";
+import KittyImage from "./Kitty.js";
 
 /**
  * Creates a registry for managing image rendering protocols.
@@ -58,6 +59,10 @@ protocolRegistry.register({
 protocolRegistry.register({
   name: "iterm2",
   render: ITerm2Image,
+});
+protocolRegistry.register({
+  name: "kitty",
+  render: KittyImage,
 });
 
 /**
@@ -122,6 +127,7 @@ const ImageRenderer = (props: ImageProps & { protocol: string }) => {
  *
  * Protocol Options:
  * - `sixel`: (experimental) Highest quality, requires Sixel graphics support
+ * - `kitty`: (experimental) High quality, requires Kitty graphics support
  * - `iterm2`: (experimental) High quality, requires iTerm2 graphics support
  * - `braille`: High resolution monochrome, requires Unicode support
  * - `halfBlock`: Good color quality, requires Unicode and color support
@@ -150,6 +156,13 @@ function Image({
    */
   const getFallbackProtocol = useCallback(
     (currentProtocol: string, attemptCount: number): string => {
+      if (currentProtocol === "kitty") {
+        return attemptCount === 0
+          ? "halfBlock"
+          : attemptCount === 1
+            ? "braille"
+            : "ascii";
+      }
       if (currentProtocol === "iterm2") {
         return attemptCount === 0
           ? "halfBlock"

--- a/src/context/TerminalInfo.tsx
+++ b/src/context/TerminalInfo.tsx
@@ -162,7 +162,7 @@ export const TerminalInfoProvider = ({
       // example format: "\x1b[4;1012;1419t"
       const parsedResponse =
         // eslint-disable-next-line no-control-regex
-        pixelDimensionsResponse.match(/\x1b\[4;(\d+);(\d+)t/);
+        pixelDimensionsResponse.match(/\x1b\[4;(\d+);(\d+);?t/);
       if (!parsedResponse || !parsedResponse[1] || !parsedResponse[2]) {
         throw new Error("Failed to determine terminal size.");
       }

--- a/src/context/TerminalInfo.tsx
+++ b/src/context/TerminalInfo.tsx
@@ -3,7 +3,6 @@ import queryEscapeSequence from "../utils/queryEscapeSequence.js";
 import supportsColor from "supports-color";
 import checkIsUnicodeSupported from "is-unicode-supported";
 import iterm2Version from "iterm2-version";
-import { get } from "http";
 
 function supportsITerm2() {
   if (process.env["TERM_PROGRAM"] === "iTerm.app") {

--- a/src/utils/generateKittyId.ts
+++ b/src/utils/generateKittyId.ts
@@ -1,0 +1,50 @@
+/**
+ * Generates unique IDs for Kitty image rendering.
+ */
+
+const MIN_ID = 1048576;
+const MAX_ID = 16777216;
+
+class KittyIdGenerator {
+  private currentId = MIN_ID;
+  private freedIds = new Set<number>();
+
+  generateId(): number {
+    // Reuse freed ID if available
+    if (this.freedIds.size > 0) {
+      const reusedId = this.freedIds.values().next().value!;
+      this.freedIds.delete(reusedId);
+      return reusedId;
+    }
+
+    // Generate new sequential ID
+    if (this.currentId >= MAX_ID) {
+      throw new Error("Kitty ID overflow: Maximum ID value reached");
+    }
+
+    return this.currentId++;
+  }
+
+  freeId(id: number): boolean {
+    // Validate ID is in our managed range and was previously allocated
+    if (id >= MIN_ID && id < this.currentId) {
+      return this.freedIds.add(id).size > this.freedIds.size - 1;
+    }
+    return false;
+  }
+
+  // Utility methods
+  getActiveIdCount(): number {
+    return this.currentId - MIN_ID - this.freedIds.size;
+  }
+
+  getAvailableIdCount(): number {
+    return MAX_ID - this.currentId + this.freedIds.size;
+  }
+}
+
+// Export singleton instance
+const generator = new KittyIdGenerator();
+export const generateId = () => generator.generateId();
+export const freeId = (id: number) => generator.freeId(id);
+export default generateId;


### PR DESCRIPTION
Implements #2 

<img width="1106" height="519" alt="image" src="https://github.com/user-attachments/assets/caac83df-eb35-4b65-bcb1-0a89e889ea83" />

## Kitty graphics protocol implementation (high level)
> Note: many terminals seem to only implement a incomplete subset of the protocol, so actual behavior may vary across terminals. I tried to implement it in a way that is compatible with most of the terminals I tested (kitty, wezterm, konsole, ghostty, wayst, warp)

- Uses direct mode to transfer image data
  - I believe temp file and shared memory object transfer modes might be more efficient, but konsole only supports direct mode
  - All other terminals I tested support temp file mode
- Sends PNG data to terminal
- A unique image id is associated with each image component
- When displayed, always use the same image id and placement id. This (theoretically) tells the terminal to automatically replace the previous displayed image with the new image **without any flicker**, so there's no need for manual cleanup like with sixel or iterm2 images.

## Compatibility
- Kitty, Konsole, Ghostty: fully compatible
- WezTerm: able to display image, but there's currently no way to render the image above text, so there might be rendering race condition issues like sixel and iterm2
- Warp, Wayst: leave behind artifacts, because they don't remove previous image when new image with same image id and placement id is displayed
- Above are the only terminals I know of that have any degree of support for kitty graphics

## Bug fixes
- Fixed a bug where the TUI would always be rendered on the bottom of the screen even if there's enough space above it
  This was caused by cursor movement bugs in my code and compatibility differences across terminals with cursor placement when rendering sixels. Now sixel, iterm2, and kitty protocols uses `ESC 7` and `ESC 8` escape sequences to directly save and restore cursor positions when rendering images to the terminal instead of performing complex restoration movements.
- Fixed sixel and iterm2 images leaving behind artifacts when moved. This was caused by imprecise calculations in my code.

## Todo/technical debt
- Kitty images are cleared when app exits
  (actually this happens to sixel and iterm2 too, most of the time)