### PR TITLE
Fix vertical offset dislocation when app height => terminal height

### DIFF
--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -158,7 +158,10 @@ function ITerm2Image(props: ImageProps) {
     const renderTimeout = setTimeout(() => {
       stdout.write("\x1b7"); // Save cursor position
       stdout.write(
-        cursorUp(componentPosition.appHeight - componentPosition.row),
+        cursorUp(componentPosition.appHeight - componentPosition.row, {
+          appHeight: componentPosition.appHeight,
+          terminalHeight: stdout.rows,
+        }),
       );
       stdout.write("\r");
       stdout.write(cursorForward(componentPosition.col));
@@ -185,7 +188,10 @@ function ITerm2Image(props: ImageProps) {
 
       stdout.write("\x1b7"); // Save cursor position
       stdout.write(
-        cursorUp(componentPosition.appHeight - componentPosition.row),
+        cursorUp(componentPosition.appHeight - componentPosition.row, {
+          appHeight: componentPosition.appHeight,
+          terminalHeight: stdout.rows,
+        }),
       );
       for (let i = 0; i < previousRenderBoundingBox.height; i++) {
         stdout.write("\r");

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -159,7 +159,12 @@ function KittyImage(props: ImageProps) {
     // assuming that the terminal implements the kitty protocol correctly
     // but some terminals do not respect the 'C=1' parameter
     stdout.write("\x1b7"); // Save cursor position
-    stdout.write(cursorUp(componentPosition.appHeight - componentPosition.row));
+    stdout.write(
+      cursorUp(componentPosition.appHeight - componentPosition.row, {
+        appHeight: componentPosition.appHeight,
+        terminalHeight: stdout.rows,
+      }),
+    );
     stdout.write("\r");
     stdout.write(cursorForward(componentPosition.col));
 

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -156,7 +156,10 @@ function SixelImage(props: ImageProps) {
     const renderTimeout = setTimeout(() => {
       stdout.write("\x1b7"); // Save cursor position
       stdout.write(
-        cursorUp(componentPosition.appHeight - componentPosition.row),
+        cursorUp(componentPosition.appHeight - componentPosition.row, {
+          appHeight: componentPosition.appHeight,
+          terminalHeight: stdout.rows,
+        }),
       );
       stdout.write("\r");
       stdout.write(cursorForward(componentPosition.col));
@@ -183,7 +186,10 @@ function SixelImage(props: ImageProps) {
 
       stdout.write("\x1b7"); // Save cursor position
       stdout.write(
-        cursorUp(componentPosition.appHeight - componentPosition.row),
+        cursorUp(componentPosition.appHeight - componentPosition.row, {
+          appHeight: componentPosition.appHeight,
+          terminalHeight: stdout.rows,
+        }),
       );
       for (let i = 0; i < previousRenderBoundingBox.height; i++) {
         stdout.write("\r");

--- a/src/utils/ansiEscapes.ts
+++ b/src/utils/ansiEscapes.ts
@@ -11,9 +11,18 @@ export function cursorForward(count: number = 1) {
 /**
  * Moves cursor up by specified number of rows.
  * @param count - Number of rows to move up (default: 1)
+ * @param context - Object containing appHeight and terminalHeight
  * @returns ANSI escape sequence string
  */
-export function cursorUp(count: number = 1) {
-  if (count === 0) return "";
-  return `\x1b[${count}A`;
+export function cursorUp(
+  count: number = 1,
+  context: { appHeight: number; terminalHeight: number },
+) {
+  // Ink appends a newline after output unless the app height exceeds the terminal height
+  // See https://github.com/vadimdemedes/ink/blob/76d221c3639f62c8c2f6c3599d51a1bf51ed1b7b/src/ink.tsx#L1040-L1042
+  // So we need to adjust the cursor movement by one row in that case to account for the absence of the newline
+  const movementCount =
+    context.appHeight >= context.terminalHeight ? count - 1 : count;
+  if (movementCount <= 0) return "";
+  return `\x1b[${movementCount}A`;
 }

--- a/tests/playwright/fixtures/vertical-offset.tsx
+++ b/tests/playwright/fixtures/vertical-offset.tsx
@@ -1,0 +1,52 @@
+import process from "node:process";
+import { Box, render, Text } from "ink";
+import React from "react";
+import Image, { ImageProtocolName, TerminalInfoProvider } from "../../../src";
+
+function parseArgs(args: string[]) {
+  const result: Record<string, boolean | string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+
+      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        result[key] = args[++i];
+      } else {
+        result[key] = true;
+      }
+    }
+  }
+
+  return result;
+}
+
+const parsed = parseArgs(process.argv.slice(2));
+const imagePath = (parsed.src as string) || "";
+const protocol = (parsed.protocol as string) || "sixel";
+const appHeight = parseInt(parsed.appHeight as string, 10) || 10;
+
+const imageHeight = 2;
+
+export function App() {
+  setInterval(() => {}, 10000);
+
+  return (
+    <TerminalInfoProvider>
+      <Box flexDirection="column" height={appHeight}>
+        <Box height={appHeight - imageHeight - 1} />
+        <Image
+          src={imagePath}
+          width={4}
+          height={imageHeight}
+          protocol={protocol as ImageProtocolName}
+        />
+        <Box height={1} />
+      </Box>
+    </TerminalInfoProvider>
+  );
+}
+
+render(<App />);

--- a/tests/playwright/image.test.ts
+++ b/tests/playwright/image.test.ts
@@ -19,29 +19,30 @@ const test = base.extend<ImageTestFixtures>({
 
 test.describe.configure({
   mode: "parallel",
-  retries: 2,
 });
 
-test("renders standalone image", async ({ ctx }) => {
-  const ps = await runFixture(
-    "simple-image.tsx",
-    ["--src", "../../example/images/full.png"],
-    ctx.terminalProxy,
-  );
-  await ps.waitForExit();
-  const bufferOutput = await ctx.terminalProxy.getBufferAsString();
-  expect(bufferOutput).toMatch(/\u2584\u2584\s*\n\u2584\u2584/);
-});
+test.describe("basic rendering", () => {
+  test("renders standalone image", async ({ ctx }) => {
+    const ps = await runFixture(
+      "simple-image.tsx",
+      ["--src", "../../example/images/full.png"],
+      ctx.terminalProxy,
+    );
+    await ps.waitForExit();
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    expect(bufferOutput).toMatch(/\u2584\u2584\s*\n\u2584\u2584/);
+  });
 
-test("shows fallback on load failure", async ({ ctx }) => {
-  const ps = await runFixture(
-    "simple-image.tsx",
-    ["--src", "non-existent.png", "--width", "12", "--height", "6"],
-    ctx.terminalProxy,
-  );
-  await ps.waitForExit();
-  const bufferOutput = await ctx.terminalProxy.getBufferAsString();
-  expect(bufferOutput).toContain("Load failed");
+  test("shows fallback on load failure", async ({ ctx }) => {
+    const ps = await runFixture(
+      "simple-image.tsx",
+      ["--src", "non-existent.png", "--width", "12", "--height", "6"],
+      ctx.terminalProxy,
+    );
+    await ps.waitForExit();
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    expect(bufferOutput).toContain("Load failed");
+  });
 });
 
 function checkCellsHaveGraphics(
@@ -55,134 +56,122 @@ function checkCellsHaveGraphics(
   return true;
 }
 
-test("renders sixel image", async ({ ctx }) => {
-  const ps = await runFixture(
-    "simple-image.tsx",
-    [
-      "--src",
-      "../../example/images/full.png",
-      "--protocol",
-      "sixel",
-      "--keepalive",
-    ],
-    ctx.terminalProxy,
-  );
-  await timeout(10000);
-  expect
-    .poll(
-      async () => {
-        const cells = await ctx.terminalProxy.cellsContainGraphics(0, 0, 4, 2);
-        return checkCellsHaveGraphics(cells);
-      },
-      {
-        intervals: [1000],
-        timeout: 10000,
-      },
-    )
-    .toBe(true);
-  await ps.kill();
-});
+const advancedImageProtocols = ["sixel", "iterm2", "kitty"];
 
-test("renders iip image", async ({ ctx }) => {
-  const ps = await runFixture(
-    "simple-image.tsx",
-    [
-      "--src",
-      "../../example/images/full.png",
-      "--protocol",
-      "iterm2",
-      "--keepalive",
-    ],
-    ctx.terminalProxy,
-  );
-  await timeout(4000);
-  expect
-    .poll(
-      async () => {
-        const cells = await ctx.terminalProxy.cellsContainGraphics(0, 0, 4, 2);
-        return checkCellsHaveGraphics(cells);
-      },
-      {
-        intervals: [1000],
-        timeout: 10000,
-      },
-    )
-    .toBe(true);
-  await ps.kill();
-});
+const verticalOffsetAppHeightCases = [
+  {
+    label: "app height < terminal height",
+    appHeight: "4",
+    expectedImageLocation: [0, 1, 4, 2],
+  },
+  {
+    label: "app height >= terminal height",
+    appHeight: "50",
+    expectedImageLocation: [0, 47, 4, 2],
+  },
+];
 
-test("renders kitty image", async ({ ctx }) => {
-  const ps = await runFixture(
-    "simple-image.tsx",
-    [
-      "--src",
-      "../../example/images/full.png",
-      "--protocol",
-      "kitty",
-      "--keepalive",
-    ],
-    ctx.terminalProxy,
-  );
-  await timeout(4000);
-  expect
-    .poll(
-      async () => {
-        const cells = await ctx.terminalProxy.cellsContainGraphics(0, 0, 4, 2);
-        return checkCellsHaveGraphics(cells);
-      },
-      {
-        intervals: [1000],
-        timeout: 10000,
-      },
-    )
-    .toBe(true);
-  await ps.kill();
-});
-
-test("keeps sixel image after exit", async ({ ctx }) => {
-  const ps = await runFixture(
-    "simple-image.tsx",
-    ["--src", "../../example/images/full.png", "--protocol", "sixel"],
-    ctx.terminalProxy,
-  );
-  await ps.waitForExit();
-  const cells = await ctx.terminalProxy.cellsContainGraphics(0, 0, 4, 2);
-  for (const cell of cells) {
-    expect(
-      cell.hasGraphic,
-      `Cell (${cell.x}, ${cell.y}) should contain graphics`,
-    ).toBe(true);
+test.describe("advanced protocols", () => {
+  for (const protocol of advancedImageProtocols) {
+    test(`renders ${protocol} image`, async ({ ctx }) => {
+      const ps = await runFixture(
+        "simple-image.tsx",
+        [
+          "--src",
+          "../../example/images/full.png",
+          "--protocol",
+          protocol,
+          "--keepalive",
+        ],
+        ctx.terminalProxy,
+      );
+      await timeout(4000);
+      await expect
+        .poll(
+          async () => {
+            const cells = await ctx.terminalProxy.cellsContainGraphics(
+              0,
+              0,
+              4,
+              2,
+            );
+            return checkCellsHaveGraphics(cells);
+          },
+          {
+            intervals: [1000],
+            timeout: 10000,
+          },
+        )
+        .toBe(true);
+      await ps.kill();
+    });
   }
 });
 
-test("keeps iip image after exit", async ({ ctx }) => {
-  const ps = await runFixture(
-    "simple-image.tsx",
-    ["--src", "../../example/images/full.png", "--protocol", "iterm2"],
-    ctx.terminalProxy,
-  );
-  await ps.waitForExit();
-  const cells = await ctx.terminalProxy.cellsContainGraphics(0, 0, 4, 2);
-  for (const cell of cells) {
-    expect(
-      cell.hasGraphic,
-      `Cell (${cell.x}, ${cell.y}) should contain graphics`,
-    ).toBe(true);
+test.describe("image persistence after exit", () => {
+  test.describe.configure({
+    retries: 2,
+  });
+
+  for (const protocol of advancedImageProtocols) {
+    test(`${protocol}`, async ({ ctx }) => {
+      const ps = await runFixture(
+        "simple-image.tsx",
+        ["--src", "../../example/images/full.png", "--protocol", protocol],
+        ctx.terminalProxy,
+      );
+      await ps.waitForExit();
+      const cells = await ctx.terminalProxy.cellsContainGraphics(0, 0, 4, 2);
+      for (const cell of cells) {
+        await expect(
+          cell.hasGraphic,
+          `Cell (${cell.x}, ${cell.y}) should contain graphics`,
+        ).toBe(true);
+      }
+    });
   }
 });
 
-test("keeps kitty image after exit", async ({ ctx }) => {
-  const ps = await runFixture(
-    "simple-image.tsx",
-    ["--src", "../../example/images/full.png", "--protocol", "kitty"],
-    ctx.terminalProxy,
-  );
-  await ps.waitForExit();
-  const cells = await ctx.terminalProxy.cellsContainGraphics(0, 0, 4, 2);
-  for (const cell of cells) {
-    expect(
-      cell.hasGraphic,
-      `Cell (${cell.x}, ${cell.y}) should contain graphics`,
-    ).toBe(true);
+test.describe("vertical offset", () => {
+  for (const protocol of advancedImageProtocols) {
+    for (const {
+      label,
+      appHeight,
+      expectedImageLocation,
+    } of verticalOffsetAppHeightCases) {
+      test(`${protocol} image with ${label}`, async ({ ctx }) => {
+        const ps = await runFixture(
+          "vertical-offset.tsx",
+          [
+            "--src",
+            "../../example/images/full.png",
+            "--protocol",
+            protocol,
+            "--appHeight",
+            appHeight,
+          ],
+          ctx.terminalProxy,
+        );
+        await timeout(4000);
+        await expect
+          .poll(
+            async () => {
+              const cells = await ctx.terminalProxy.cellsContainGraphics(
+                expectedImageLocation[0],
+                expectedImageLocation[1],
+                expectedImageLocation[2],
+                expectedImageLocation[3],
+              );
+              return checkCellsHaveGraphics(cells);
+            },
+            {
+              intervals: [1000],
+              timeout: 10000,
+            },
+          )
+          .toBe(true);
+        await ps.kill();
+      });
+    }
   }
 });

--- a/tests/playwright/terminal.ts
+++ b/tests/playwright/terminal.ts
@@ -161,8 +161,16 @@ class TerminalProxy {
         const results: Array<{ x: number; y: number; hasGraphic: boolean }> =
           [];
 
-        for (let row = y as number; row < (height as number); row++) {
-          for (let col = x as number; col < (width as number); col++) {
+        for (
+          let row = y as number;
+          row < (y as number) + (height as number);
+          row++
+        ) {
+          for (
+            let col = x as number;
+            col < (x as number) + (width as number);
+            col++
+          ) {
             results.push({
               x: col,
               y: row,


### PR DESCRIPTION
Fixed a visual bug where images using `sixel`, `iterm2`, and `kitty` protocols are rendered one line above their location, when the Ink app's total height is greater than the terminal height.
Ink does not render a newline after the app content if app height >= terminal height, see https://github.com/vadimdemedes/ink/blob/76d221c3639f62c8c2f6c3599d51a1bf51ed1b7b/src/ink.tsx#L1040-L1042. So we need to move up the cursor one line fewer when rendering images.

## Changes
- Modified `cursorUp()` to handle app height > terminal height special case in `ansiEscapes.ts`
- Added regression tests for the fix