### PR TITLE
feat: support percentage-based width/height on Image component

### DIFF
--- a/src/components/image/Ascii.tsx
+++ b/src/components/image/Ascii.tsx
@@ -35,8 +35,25 @@ function AsciiImage(props: ImageProps) {
   const containerRef = useRef<DOMElement | null>(null);
   const terminalCapabilities = useTerminalCapabilities();
   const { src, width, height, alt, allowPartial } = props;
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const [measuredHeight, setMeasuredHeight] = useState(0);
+
+  const needsMeasure = typeof width === "string" || typeof height === "string";
+  useEffect(() => {
+    if (!needsMeasure) return;
+    if (!containerRef.current) return;
+
+    const { width: w, height: h } = measureElement(containerRef.current);
+    if (w > 0) setMeasuredWidth(w);
+    if (h > 0) setMeasuredHeight(h);
+  });
+
+  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
+  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
 
   useEffect(() => {
+    if (resolvedWidth === 0 || resolvedHeight === 0) return;
+
     const generateImageOutput = async () => {
       const image = await fetchImage(src, allowPartial);
       if (!image) {
@@ -45,7 +62,7 @@ function AsciiImage(props: ImageProps) {
       }
       setHasError(false);
 
-      image.resize({ w: width, h: height });
+      image.resize({ w: resolvedWidth, h: resolvedHeight });
       const resizedImage = await getRawPixels(image);
 
       const output = await toAscii(
@@ -55,7 +72,7 @@ function AsciiImage(props: ImageProps) {
       setImageOutput(output);
     };
     generateImageOutput();
-  }, [src, width, height, terminalCapabilities, allowPartial]);
+  }, [src, resolvedWidth, resolvedHeight, terminalCapabilities, allowPartial]);
 
   return (
     <Box

--- a/src/components/image/Braille.tsx
+++ b/src/components/image/Braille.tsx
@@ -45,8 +45,25 @@ function BrailleImage(props: ImageProps) {
   const [hasError, setHasError] = useState<boolean>(false);
   const containerRef = useRef<DOMElement | null>(null);
   const { src, width, height, alt, allowPartial } = props;
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const [measuredHeight, setMeasuredHeight] = useState(0);
+
+  const needsMeasure = typeof width === "string" || typeof height === "string";
+  useEffect(() => {
+    if (!needsMeasure) return;
+    if (!containerRef.current) return;
+
+    const { width: w, height: h } = measureElement(containerRef.current);
+    if (w > 0) setMeasuredWidth(w);
+    if (h > 0) setMeasuredHeight(h);
+  });
+
+  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
+  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
 
   useEffect(() => {
+    if (resolvedWidth === 0 || resolvedHeight === 0) return;
+
     const generateImageOutput = async () => {
       const image = await fetchImage(src, allowPartial);
       if (!image) {
@@ -55,14 +72,14 @@ function BrailleImage(props: ImageProps) {
       }
       setHasError(false);
 
-      image.resize({ w: width * 2, h: height * 4 });
+      image.resize({ w: resolvedWidth * 2, h: resolvedHeight * 4 });
       const resizedImage = await getRawPixels(image);
 
       const output = await toBraille(resizedImage);
       setImageOutput(output);
     };
     generateImageOutput();
-  }, [src, width, height, allowPartial]);
+  }, [src, resolvedWidth, resolvedHeight, allowPartial]);
 
   return (
     <Box

--- a/src/components/image/HalfBlock.tsx
+++ b/src/components/image/HalfBlock.tsx
@@ -37,8 +37,25 @@ function HalfBlockImage(props: ImageProps) {
   const [hasError, setHasError] = useState<boolean>(false);
   const containerRef = useRef<DOMElement | null>(null);
   const { src, width, height, alt, allowPartial } = props;
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const [measuredHeight, setMeasuredHeight] = useState(0);
+
+  const needsMeasure = typeof width === "string" || typeof height === "string";
+  useEffect(() => {
+    if (!needsMeasure) return;
+    if (!containerRef.current) return;
+
+    const { width: w, height: h } = measureElement(containerRef.current);
+    if (w > 0) setMeasuredWidth(w);
+    if (h > 0) setMeasuredHeight(h);
+  });
+
+  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
+  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
 
   useEffect(() => {
+    if (resolvedWidth === 0 || resolvedHeight === 0) return;
+
     const generateImageOutput = async () => {
       const image = await fetchImage(src, allowPartial);
       if (!image) {
@@ -47,14 +64,14 @@ function HalfBlockImage(props: ImageProps) {
       }
       setHasError(false);
 
-      image.resize({ w: width, h: height * 2 });
+      image.resize({ w: resolvedWidth, h: resolvedHeight * 2 });
       const resizedImage = await getRawPixels(image);
 
       const output = await toHalfBlocks(resizedImage);
       setImageOutput(output);
     };
     generateImageOutput();
-  }, [src, width, height, allowPartial]);
+  }, [src, resolvedWidth, resolvedHeight, allowPartial]);
 
   return (
     <Box

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -193,8 +193,8 @@ function ITerm2Image(props: ImageProps) {
       previousRenderBoundingBox = {
         row: stdout.rows - componentPosition.appHeight + componentPosition.row,
         col: componentPosition.col,
-        width: width,
-        height: height,
+        width: resolvedWidth,
+        height: resolvedHeight,
       };
     }, 100); // Delay to allow Ink/terminal to finish its render
 

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -1,4 +1,11 @@
-import { Box, type DOMElement, Newline, Text, useStdout } from "ink";
+import {
+  Box,
+  type DOMElement,
+  measureElement,
+  Newline,
+  Text,
+  useStdout,
+} from "ink";
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   useTerminalCapabilities,
@@ -62,9 +69,24 @@ function ITerm2Image(props: ImageProps) {
   const terminalDimensions = useTerminalDimensions();
   const shouldCleanupRef = useRef<boolean>(true);
   const { src, width, height, alt, allowPartial } = props;
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const [measuredHeight, setMeasuredHeight] = useState(0);
 
   // TODO: If we upgrade to Ink 6 we will need to deal with Box background colors when rendering/cleaning up
   // const inheritedBackgroundColor = useContext(backgroundContext);
+
+  const needsMeasure = typeof width === "string" || typeof height === "string";
+  useEffect(() => {
+    if (!needsMeasure) return;
+    if (!containerRef.current) return;
+
+    const { width: w, height: h } = measureElement(containerRef.current);
+    if (w > 0) setMeasuredWidth(w);
+    if (h > 0) setMeasuredHeight(h);
+  });
+
+  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
+  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
 
   /**
    * Main effect for image processing and ITerm2 conversion.
@@ -78,9 +100,10 @@ function ITerm2Image(props: ImageProps) {
    * 6. Tracks actual size in terminal cells for cleanup purposes
    */
   useEffect(() => {
-    const generateImageOutput = async () => {
-      if (!terminalDimensions) return;
+    if (resolvedWidth === 0 || resolvedHeight === 0) return;
+    if (!terminalDimensions) return;
 
+    const generateImageOutput = async () => {
       const image = await fetchImage(src, allowPartial);
       if (!image) {
         setHasError(true);
@@ -89,19 +112,19 @@ function ITerm2Image(props: ImageProps) {
       setHasError(false);
 
       image.resize({
-        w: width * terminalDimensions.cellWidth,
-        h: height * terminalDimensions.cellHeight,
+        w: resolvedWidth * terminalDimensions.cellWidth,
+        h: resolvedHeight * terminalDimensions.cellHeight,
       });
       const resizedImage = await getPngBuffer(image);
 
       const output = toITerm2(resizedImage, {
-        width: width * terminalDimensions.cellWidth,
-        height: height * terminalDimensions.cellHeight,
+        width: resolvedWidth * terminalDimensions.cellWidth,
+        height: resolvedHeight * terminalDimensions.cellHeight,
       });
       setImageOutput(output);
     };
     generateImageOutput();
-  }, [src, width, height, terminalDimensions, allowPartial]);
+  }, [src, resolvedWidth, resolvedHeight, terminalDimensions, allowPartial]);
 
   /**
    * Critical rendering effect for ITerm2 image display.
@@ -171,8 +194,8 @@ function ITerm2Image(props: ImageProps) {
       previousRenderBoundingBox = {
         row: stdout.rows - componentPosition.appHeight + componentPosition.row,
         col: componentPosition.col,
-        width: width * terminalDimensions!.cellWidth,
-        height: height * terminalDimensions!.cellHeight,
+        width: resolvedWidth * terminalDimensions!.cellWidth,
+        height: resolvedHeight * terminalDimensions!.cellHeight,
       };
     }, 100); // Delay to allow Ink/terminal to finish its render
 

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -1,4 +1,11 @@
-import { Box, type DOMElement, Newline, Text, useStdout } from "ink";
+import {
+  Box,
+  type DOMElement,
+  measureElement,
+  Newline,
+  Text,
+  useStdout,
+} from "ink";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   useTerminalCapabilities,
@@ -59,9 +66,24 @@ function KittyImage(props: ImageProps) {
   const terminalDimensions = useTerminalDimensions();
   const shouldCleanupRef = useRef<boolean>(true);
   const { src, width, height, alt, allowPartial } = props;
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const [measuredHeight, setMeasuredHeight] = useState(0);
 
   // TODO: If we upgrade to Ink 6 we will need to deal with Box background colors when rendering/cleaning up
   // const inheritedBackgroundColor = useContext(backgroundContext);
+
+  const needsMeasure = typeof width === "string" || typeof height === "string";
+  useEffect(() => {
+    if (!needsMeasure) return;
+    if (!containerRef.current) return;
+
+    const { width: w, height: h } = measureElement(containerRef.current);
+    if (w > 0) setMeasuredWidth(w);
+    if (h > 0) setMeasuredHeight(h);
+  });
+
+  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
+  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
 
   /**
    * Main effect for image processing and Kitty conversion.
@@ -73,9 +95,10 @@ function KittyImage(props: ImageProps) {
    * 4. Transfers image data to the terminal using Kitty protocol
    */
   useEffect(() => {
-    const generateImageOutput = async () => {
-      if (!terminalDimensions) return;
+    if (resolvedWidth === 0 || resolvedHeight === 0) return;
+    if (!terminalDimensions) return;
 
+    const generateImageOutput = async () => {
       const image = await fetchImage(src, allowPartial);
       if (!image) {
         setHasError(true);
@@ -84,8 +107,8 @@ function KittyImage(props: ImageProps) {
       setHasError(false);
 
       image.resize({
-        w: width * terminalDimensions.cellWidth,
-        h: height * terminalDimensions.cellHeight,
+        w: resolvedWidth * terminalDimensions.cellWidth,
+        h: resolvedHeight * terminalDimensions.cellHeight,
       });
 
       try {
@@ -121,7 +144,14 @@ function KittyImage(props: ImageProps) {
       }
     };
     generateImageOutput();
-  }, [src, width, height, terminalDimensions, allowPartial, stdout.write]);
+  }, [
+    src,
+    resolvedWidth,
+    resolvedHeight,
+    terminalDimensions,
+    allowPartial,
+    stdout.write,
+  ]);
 
   /**
    * Critical rendering effect for Kitty image display.

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -1,4 +1,11 @@
-import { Box, type DOMElement, Newline, Text, useStdout } from "ink";
+import {
+  Box,
+  type DOMElement,
+  measureElement,
+  Newline,
+  Text,
+  useStdout,
+} from "ink";
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 // import { backgroundContext } from "ink";
 import { image2sixel } from "sixel";
@@ -63,9 +70,24 @@ function SixelImage(props: ImageProps) {
   const terminalDimensions = useTerminalDimensions();
   const shouldCleanupRef = useRef<boolean>(true);
   const { src, width, height, alt, allowPartial } = props;
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const [measuredHeight, setMeasuredHeight] = useState(0);
 
   // TODO: If we upgrade to Ink 6 we will need to deal with Box background colors when rendering/cleaning up
   // const inheritedBackgroundColor = useContext(backgroundContext);
+
+  const needsMeasure = typeof width === "string" || typeof height === "string";
+  useEffect(() => {
+    if (!needsMeasure) return;
+    if (!containerRef.current) return;
+
+    const { width: w, height: h } = measureElement(containerRef.current);
+    if (w > 0) setMeasuredWidth(w);
+    if (h > 0) setMeasuredHeight(h);
+  });
+
+  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
+  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
 
   /**
    * Main effect for image processing and Sixel conversion.
@@ -79,9 +101,10 @@ function SixelImage(props: ImageProps) {
    * 6. Tracks actual size in terminal cells for cleanup purposes
    */
   useEffect(() => {
-    const generateImageOutput = async () => {
-      if (!terminalDimensions) return;
+    if (resolvedWidth === 0 || resolvedHeight === 0) return;
+    if (!terminalDimensions) return;
 
+    const generateImageOutput = async () => {
       const image = await fetchImage(src, allowPartial);
       if (!image) {
         setHasError(true);
@@ -90,8 +113,8 @@ function SixelImage(props: ImageProps) {
       setHasError(false);
 
       image.resize({
-        w: width * terminalDimensions.cellWidth,
-        h: height * terminalDimensions.cellHeight,
+        w: resolvedWidth * terminalDimensions.cellWidth,
+        h: resolvedHeight * terminalDimensions.cellHeight,
       });
       const resizedImage = await getRawPixels(image);
 
@@ -99,7 +122,7 @@ function SixelImage(props: ImageProps) {
       setImageOutput(output);
     };
     generateImageOutput();
-  }, [src, width, height, terminalDimensions, allowPartial]);
+  }, [src, resolvedWidth, resolvedHeight, terminalDimensions, allowPartial]);
 
   /**
    * Critical rendering effect for Sixel image display.
@@ -169,8 +192,8 @@ function SixelImage(props: ImageProps) {
       previousRenderBoundingBox = {
         row: stdout.rows - componentPosition.appHeight + componentPosition.row,
         col: componentPosition.col,
-        width: width,
-        height: height,
+        width: componentPosition.width,
+        height: componentPosition.height,
       };
     }, 100); // Delay to allow Ink/terminal to finish its render
 

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -191,8 +191,8 @@ function SixelImage(props: ImageProps) {
       previousRenderBoundingBox = {
         row: stdout.rows - componentPosition.appHeight + componentPosition.row,
         col: componentPosition.col,
-        width: componentPosition.width,
-        height: componentPosition.height,
+        width: resolvedWidth,
+        height: resolvedHeight,
       };
     }, 100); // Delay to allow Ink/terminal to finish its render
 

--- a/src/components/image/protocol.ts
+++ b/src/components/image/protocol.ts
@@ -14,9 +14,9 @@ export interface ImageProps {
    */
   src: string;
   /** Width in terminal cells or a percentage */
-  width: number;
+  width: number | string;
   /** Height in terminal cells or a percentage */
-  height: number;
+  height: number | string;
   /** Alternative text displayed while loading or on error */
   alt?: string;
   /** Supports partially loaded image reading */

--- a/tests/playwright/fixtures/percentage-size.tsx
+++ b/tests/playwright/fixtures/percentage-size.tsx
@@ -1,0 +1,63 @@
+import process from "node:process";
+import { Box, render, Text } from "ink";
+import React from "react";
+import Image, { ImageProtocolName, TerminalInfoProvider } from "../../../src";
+
+function parseArgs(args: string[]) {
+  const result: Record<string, boolean | string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+
+      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        result[key] = args[++i];
+      } else {
+        result[key] = true;
+      }
+    }
+  }
+
+  return result;
+}
+
+const parsed = parseArgs(process.argv.slice(2));
+const imagePath = (parsed.src as string) || "";
+const widthArg = parsed.width || "100%";
+const heightArg = parsed.height || "100%";
+const protocol = (parsed.protocol as string) || "halfBlock";
+const parentWidth = parseInt(parsed.parentWidth as string, 10) || 20;
+const parentHeight = parseInt(parsed.parentHeight as string, 10) || 10;
+const keepalive = parsed.keepalive === true;
+
+let width: number | string = widthArg as string;
+if (typeof widthArg === "string" && !widthArg.endsWith("%")) {
+  width = parseInt(widthArg, 10);
+}
+let height: number | string = heightArg as string;
+if (typeof heightArg === "string" && !heightArg.endsWith("%")) {
+  height = parseInt(heightArg, 10);
+}
+
+export function App() {
+  if (keepalive) {
+    setInterval(() => {}, 10000);
+  }
+
+  return (
+    <TerminalInfoProvider>
+      <Box flexDirection="column" width={parentWidth} height={parentHeight}>
+        <Image
+          src={imagePath}
+          width={width}
+          height={height}
+          protocol={protocol as ImageProtocolName}
+        />
+      </Box>
+    </TerminalInfoProvider>
+  );
+}
+
+render(<App />);

--- a/tests/playwright/image.test.ts
+++ b/tests/playwright/image.test.ts
@@ -21,16 +21,38 @@ test.describe.configure({
   mode: "parallel",
 });
 
+function checkCellsHaveGraphics(
+  cells: { x: number; y: number; hasGraphic: boolean }[],
+): boolean {
+  for (const cell of cells) {
+    if (!cell.hasGraphic) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const basicImageProtocols = ["ascii", "braille", "halfBlock"];
+const advancedImageProtocols = ["sixel", "iterm2", "kitty"];
+const imageProtocols = [...basicImageProtocols, ...advancedImageProtocols];
+
 test.describe("basic rendering", () => {
   test("renders standalone image", async ({ ctx }) => {
     const ps = await runFixture(
       "simple-image.tsx",
-      ["--src", "../../example/images/full.png"],
+      [
+        "--src",
+        "../../example/images/full.png",
+        "--width",
+        "4",
+        "--height",
+        "2",
+      ],
       ctx.terminalProxy,
     );
     await ps.waitForExit();
     const bufferOutput = await ctx.terminalProxy.getBufferAsString();
-    expect(bufferOutput).toMatch(/\u2584\u2584\s*\n\u2584\u2584/);
+    expect(bufferOutput).toMatch(/^\u2584{4}\s*\n\u2584{4}\s*$/);
   });
 
   test("shows fallback on load failure", async ({ ctx }) => {
@@ -44,32 +66,6 @@ test.describe("basic rendering", () => {
     expect(bufferOutput).toContain("Load failed");
   });
 });
-
-function checkCellsHaveGraphics(
-  cells: { x: number; y: number; hasGraphic: boolean }[],
-): boolean {
-  for (const cell of cells) {
-    if (!cell.hasGraphic) {
-      return false;
-    }
-  }
-  return true;
-}
-
-const advancedImageProtocols = ["sixel", "iterm2", "kitty"];
-
-const verticalOffsetAppHeightCases = [
-  {
-    label: "app height < terminal height",
-    appHeight: "4",
-    expectedImageLocation: [0, 1, 4, 2],
-  },
-  {
-    label: "app height >= terminal height",
-    appHeight: "50",
-    expectedImageLocation: [0, 47, 4, 2],
-  },
-];
 
 test.describe("advanced protocols", () => {
   for (const protocol of advancedImageProtocols) {
@@ -131,6 +127,113 @@ test.describe("image persistence after exit", () => {
     });
   }
 });
+
+test.describe("percentage sizing", () => {
+  test("100% size image", async ({ ctx }) => {
+    const ps = await runFixture(
+      "percentage-size.tsx",
+      [
+        "--src",
+        "../../example/images/full.png",
+        "--width",
+        "100%",
+        "--height",
+        "100%",
+        "--parentWidth",
+        "4",
+        "--parentHeight",
+        "2",
+      ],
+      ctx.terminalProxy,
+    );
+    await ps.waitForExit();
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    // expect 2 lines of 4 half-block chars each
+    expect(bufferOutput).toMatch(/^\u2584{4}[ \t]*(\n\u2584{4}[ \t]*){1}\s*$/);
+  });
+
+  test("50% size image", async ({ ctx }) => {
+    const ps = await runFixture(
+      "percentage-size.tsx",
+      [
+        "--src",
+        "../../example/images/full.png",
+        "--width",
+        "50%",
+        "--height",
+        "50%",
+        "--parentWidth",
+        "4",
+        "--parentHeight",
+        "2",
+      ],
+      ctx.terminalProxy,
+    );
+    await ps.waitForExit();
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    // expect 1 line of 2 half-block chars
+    expect(bufferOutput).toMatch(/^\u2584{2}\s*$/);
+  });
+
+  test("percentage width", async ({ ctx }) => {
+    const ps = await runFixture(
+      "percentage-size.tsx",
+      [
+        "--src",
+        "../../example/images/full.png",
+        "--width",
+        "100%",
+        "--height",
+        "2",
+        "--parentWidth",
+        "4",
+        "--parentHeight",
+        "2",
+      ],
+      ctx.terminalProxy,
+    );
+    await ps.waitForExit();
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    // expect 2 lines of 4 half-block chars each, since height is fixed at 2 lines but width is 100% of parent
+    expect(bufferOutput).toMatch(/^\u2584{4}\s*\n\u2584{4}\s*$/);
+  });
+
+  test("percentage height", async ({ ctx }) => {
+    const ps = await runFixture(
+      "percentage-size.tsx",
+      [
+        "--src",
+        "../../example/images/full.png",
+        "--width",
+        "4",
+        "--height",
+        "100%",
+        "--parentWidth",
+        "4",
+        "--parentHeight",
+        "2",
+      ],
+      ctx.terminalProxy,
+    );
+    await ps.waitForExit();
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    // expect 2 lines of 4 half-block chars each, since width is fixed at 4 chars but height is 100% of parent
+    expect(bufferOutput).toMatch(/^\u2584{4}\s*\n\u2584{4}\s*$/);
+  });
+});
+
+const verticalOffsetAppHeightCases = [
+  {
+    label: "app height < terminal height",
+    appHeight: "4",
+    expectedImageLocation: [0, 1, 4, 2],
+  },
+  {
+    label: "app height >= terminal height",
+    appHeight: "50",
+    expectedImageLocation: [0, 47, 4, 2],
+  },
+];
 
 test.describe("vertical offset", () => {
   for (const protocol of advancedImageProtocols) {


### PR DESCRIPTION
## Summary

The `<Image>` component now accepts percentage strings for `width` and `height` (e.g. `width="50%"`), matching the same behavior as Ink's `<Box>` component.

Addresses #22 

## Changes

### `ImageProps` (`protocol.ts`)
- `width` and `height` widened from `number` to `number | string`

### All six renderers (`HalfBlock`, `Ascii`, `Braille`, `Sixel`, `ITerm2`, `Kitty`)

Each renderer now resolves percentage dimensions by measuring the container box after Yoga layout, using Ink's `measureElement()`:

1. **Numeric values** (e.g. `width={40}`) are used directly — computed during render, no extra render cycle
2. **Percentage strings** (e.g. `width="50%"`) are resolved post-layout via `measureElement()` on the container ref, then used for image resizing
3. Raw `width`/`height` values are passed through to the inner `<Box>`, which already handles percentage strings via Yoga's `setWidthPercent`/`setHeightPercent`

### Usage

```tsx
<Box width={40} height={20}>
  <Image src="photo.png" width="50%" height="100%" />
</Box>
```

The image renders at 20×20 cells (50% of parent width, 100% of parent height).

### Tests
- New `percentage-size.tsx` Playwright fixture wrapping `<Image>` in a fixed-size `<Box>`
- 4 test cases covering: 100% both, 50% both, percentage width only, percentage height only

## Notes

- Silently fails and renders nothing when given invalid size props (negative numbers, garbage strings), which matches Ink's `<Box>`'s behavior