### PR TITLE
feat: screen reader accessibility

### DIFF
--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -1,3 +1,4 @@
+import { Box, Text, useIsScreenReaderEnabled } from "ink";
 import React, { useCallback, useState } from "react";
 import { useTerminalCapabilities } from "../../context/TerminalInfo.js";
 import useProtocol from "../../hooks/useProtocol.js";
@@ -95,7 +96,23 @@ function Image({
   protocol: specifiedProtocol,
   ...props
 }: Omit<ImageProps & { protocol?: ImageProtocolName }, "onSupportDetected">) {
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
   const protocol = useProtocol(specifiedProtocol);
+
+  if (isScreenReaderEnabled) {
+    const { src, alt, width, height } = props;
+    // Simulate aria-role because Ink doesn't have a image role
+    const label = `image: ${alt || src}`;
+
+    return (
+      <Box
+        width={width}
+        height={height}
+        aria-label={label}
+        flexDirection="column"
+      />
+    );
+  }
 
   return <ImageRenderer protocol={protocol} key={protocol} {...props} />;
 }


### PR DESCRIPTION
Implement accessibility for screen readers, integrating with Ink's screen reader system.

Closes #6 

## Changes
In `src/components/image/index.tsx`:
- In the top-level Image component, calls useIsScreenReaderEnabled() from Ink
- When a screen reader is active, it renders only the alt text (or "Image: <src>" as fallback) in a Box with aria-label, bypassing all protocol renderers entirely
- When no screen reader is active, behavior is unchanged

Users enable this by passing `{isScreenReaderEnabled: true}` to Ink's render() or setting environment variable `INK_SCREEN_READER=true`.
