### PR TITLE
Refactor: shared hooks, per-protocol renderers, visibility system, LRU cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+After making non-trivial changes, always run linter and tests, and fix any issues that arise.
+Prefer using commands (`biome format`, `biome lint --fix`) over manual edits to fix formatting and lint issues.
+
+Add new tests after implementing new features. In generally:
+- Tests that don't require the terminal interpreting escape sequences should go under `tests/vitest`
+- tests that require a full-fledged terminal environment should go under `tests/playwright`, which spins up a real xterm.js terminal to run tests

--- a/example/image.tsx
+++ b/example/image.tsx
@@ -13,12 +13,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function getImagePath(): string {
-  return `${__dirname}/images/${getAllowPartial() ? "partial.jpeg" : "full.png"}`;
-}
-
-function getAllowPartial() {
-  const args = process.argv.slice(2);
-  return args.length > 0 && args[0].startsWith("--partial");
+  return `${__dirname}/images/full.png`;
 }
 
 type ProtocolConfig = {
@@ -137,7 +132,6 @@ function ProtocolDemo({ config }: { config: ProtocolConfig }) {
             height={12}
             protocol={config.protocol}
             alt={`${config.name} demo`}
-            allowPartial={getAllowPartial()}
           />
         ) : (
           <Box

--- a/src/components/ImageBox.tsx
+++ b/src/components/ImageBox.tsx
@@ -1,0 +1,44 @@
+import { Box, type DOMElement, Newline, Text } from "ink";
+import React, { forwardRef } from "react";
+
+export interface ImageBoxProps {
+  width: number | string;
+  height: number | string;
+  alt?: string;
+  error?: boolean;
+  loaded?: boolean;
+  children?: React.ReactNode;
+}
+
+const ImageBox = forwardRef<DOMElement, ImageBoxProps>(function ImageBox(
+  { width, height, alt, error, loaded, children },
+  ref,
+) {
+  return (
+    <Box ref={ref} flexDirection="column" width={width} height={height}>
+      {loaded && children ? (
+        children
+      ) : (
+        <Box
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          overflow="hidden"
+        >
+          {alt ? (
+            <Text color="gray">{alt}</Text>
+          ) : error ? (
+            <Text color="red">
+              X<Newline />
+              Load failed
+            </Text>
+          ) : (
+            <Text color="gray">Loading...</Text>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+});
+
+export default ImageBox;

--- a/src/components/image/Ascii.tsx
+++ b/src/components/image/Ascii.tsx
@@ -1,79 +1,31 @@
-import { Box, type DOMElement, measureElement, Newline, Text } from "ink";
-import React, { useEffect, useRef, useState } from "react";
+import { Box, Newline, Text } from "ink";
+import React, { useMemo } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
+import { useImage } from "../../hooks/useImage.js";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import { renderAscii } from "../../renderers/ascii.js";
-import { fetchImage, getRawPixels } from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
-/**
- * ASCII Image Rendering Component
- *
- * Converts images to ASCII art using character-based representation.
- * This is the most compatible rendering method as it works in all terminals.
- *
- * Features:
- * - Works in all terminal environments (fallback protocol)
- * - Supports both monochrome and colored ASCII art
- * - Automatic color detection based on terminal capabilities
- *
- * Technical Details:
- * - Uses the 'ascii-art' library for image-to-ASCII conversion
- * - Applies image preprocessing (sharpening, normalization) for better results
- * - Color support is automatically detected and applied when available
- * - Temporary files are created and cleaned up during conversion
- *
- * @param props - Image rendering properties
- * @returns JSX element containing ASCII art representation of the image
- */
 function AsciiImage(props: ImageProps) {
-  const [imageOutput, setImageOutput] = useState<string | null>(null);
-  const [hasError, setHasError] = useState<boolean>(false);
-  const containerRef = useRef<DOMElement | null>(null);
   const terminalInfo = useTerminalInfo();
   const { src, width, height, alt, allowPartial } = props;
-  const [measuredWidth, setMeasuredWidth] = useState(0);
-  const [measuredHeight, setMeasuredHeight] = useState(0);
 
-  const needsMeasure = typeof width === "string" || typeof height === "string";
-  useEffect(() => {
-    if (!needsMeasure) return;
-    if (!containerRef.current) return;
+  const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
+    width,
+    height,
+  );
 
-    const { width: w, height: h } = measureElement(containerRef.current);
-    if (w > 0) setMeasuredWidth(w);
-    if (h > 0) setMeasuredHeight(h);
+  const { imageData, error } = useImage({
+    src,
+    pixelWidth: resolvedWidth,
+    pixelHeight: resolvedHeight,
+    mode: "pixels",
   });
 
-  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
-  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
-
-  useEffect(() => {
-    if (resolvedWidth === 0 || resolvedHeight === 0) return;
-
-    const generateImageOutput = async () => {
-      const image = await fetchImage(src, allowPartial);
-      if (!image) {
-        setHasError(true);
-        return;
-      }
-      setHasError(false);
-
-      image.resize({ w: resolvedWidth, h: resolvedHeight });
-      const resizedImage = await getRawPixels(image);
-
-      const output = renderAscii(resizedImage, {
-        colored: terminalInfo?.supportsColor,
-      });
-      setImageOutput(output);
-    };
-    generateImageOutput();
-  }, [
-    src,
-    resolvedWidth,
-    resolvedHeight,
-    terminalInfo?.supportsColor,
-    allowPartial,
-  ]);
+  const imageOutput = useMemo(() => {
+    if (!imageData) return null;
+    return renderAscii(imageData, { colored: terminalInfo?.supportsColor });
+  }, [imageData, terminalInfo?.supportsColor]);
 
   return (
     <Box
@@ -91,7 +43,7 @@ function AsciiImage(props: ImageProps) {
         <Box flexDirection="column" alignItems="center" justifyContent="center">
           {alt ? (
             <Text color="gray">{alt}</Text>
-          ) : hasError ? (
+          ) : error ? (
             <Text color="red">
               X<Newline />
               Load failed

--- a/src/components/image/Ascii.tsx
+++ b/src/components/image/Ascii.tsx
@@ -1,12 +1,8 @@
-import chalk from "chalk";
 import { Box, type DOMElement, measureElement, Newline, Text } from "ink";
 import React, { useEffect, useRef, useState } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
-import {
-  fetchImage,
-  getRawPixels,
-  type ImageOutputInfo,
-} from "../../utils/image.js";
+import { renderAscii } from "../../renderers/ascii.js";
+import { fetchImage, getRawPixels } from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
 /**
@@ -65,7 +61,9 @@ function AsciiImage(props: ImageProps) {
       image.resize({ w: resolvedWidth, h: resolvedHeight });
       const resizedImage = await getRawPixels(image);
 
-      const output = await toAscii(resizedImage, terminalInfo?.supportsColor);
+      const output = renderAscii(resizedImage, {
+        colored: terminalInfo?.supportsColor,
+      });
       setImageOutput(output);
     };
     generateImageOutput();
@@ -105,48 +103,6 @@ function AsciiImage(props: ImageProps) {
       )}
     </Box>
   );
-}
-
-async function toAscii(
-  imageData: {
-    data: Buffer;
-    info: ImageOutputInfo;
-  },
-  colored: boolean = true,
-) {
-  const { data, info } = imageData;
-  const { width, height, channels } = info;
-
-  // ascii characters ordered by brightness
-  const ascii_chars =
-    "$@B%8&WM#*oahkbdpqwmZO0QLCJUYXzcvunxrjft/\\|()1{}[]?-_+~<>i!lI;:,\"^`'. ";
-
-  let result = "";
-  for (let y = 0; y < height; y++) {
-    for (let x = 0; x < width; x++) {
-      const pixelIndex = (y * width + x) * channels;
-
-      const r = data[pixelIndex] as number;
-      const g = data[pixelIndex + 1] as number;
-      const b = data[pixelIndex + 2] as number;
-      const a = channels === 4 ? (data[pixelIndex + 3] as number) : 255;
-
-      // this is different from perceived luminance
-      const intensity = r + g + b + a === 0 ? 0 : (r + g + b + a) / (255 * 4);
-      const pixel_char =
-        ascii_chars[
-          ascii_chars.length -
-            1 -
-            Math.floor(intensity * (ascii_chars.length - 1))
-        ];
-
-      result += colored ? chalk.rgb(r, g, b)(pixel_char) : pixel_char;
-    }
-
-    result += "\n";
-  }
-
-  return result;
 }
 
 export default AsciiImage;

--- a/src/components/image/Ascii.tsx
+++ b/src/components/image/Ascii.tsx
@@ -1,14 +1,15 @@
-import { Box, Newline, Text } from "ink";
+import { Text } from "ink";
 import React, { useMemo } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import { useImage } from "../../hooks/useImage.js";
 import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import { renderAscii } from "../../renderers/ascii.js";
+import ImageBox from "../ImageBox.js";
 import type { ImageProps } from "./protocol.js";
 
 function AsciiImage(props: ImageProps) {
   const terminalInfo = useTerminalInfo();
-  const { src, width, height, alt, allowPartial } = props;
+  const { src, width, height, alt } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -28,32 +29,19 @@ function AsciiImage(props: ImageProps) {
   }, [imageData, terminalInfo?.supportsColor]);
 
   return (
-    <Box
+    <ImageBox
       ref={containerRef}
-      flexDirection="column"
       width={width}
       height={height}
+      alt={alt}
+      error={error}
+      loaded={!!imageOutput}
     >
-      {imageOutput ? (
-        imageOutput
-          .split("\n")
-          // biome-ignore lint/suspicious/noArrayIndexKey: static content, won't change
-          .map((line, idx) => <Text key={`${line}-${idx}`}>{line}</Text>)
-      ) : (
-        <Box flexDirection="column" alignItems="center" justifyContent="center">
-          {alt ? (
-            <Text color="gray">{alt}</Text>
-          ) : error ? (
-            <Text color="red">
-              X<Newline />
-              Load failed
-            </Text>
-          ) : (
-            <Text color="gray">Loading...</Text>
-          )}
-        </Box>
-      )}
-    </Box>
+      {imageOutput?.split("\n").map((line, idx) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static content, won't change
+        <Text key={`${line}-${idx}`}>{line}</Text>
+      ))}
+    </ImageBox>
   );
 }
 

--- a/src/components/image/Braille.tsx
+++ b/src/components/image/Braille.tsx
@@ -1,12 +1,13 @@
-import { Box, Newline, Text } from "ink";
+import { Text } from "ink";
 import React, { useMemo } from "react";
 import { useImage } from "../../hooks/useImage.js";
 import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import { renderBraille } from "../../renderers/braille.js";
+import ImageBox from "../ImageBox.js";
 import type { ImageProps } from "./protocol.js";
 
 function BrailleImage(props: ImageProps) {
-  const { src, width, height, alt, allowPartial } = props;
+  const { src, width, height, alt } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -26,32 +27,19 @@ function BrailleImage(props: ImageProps) {
   }, [imageData]);
 
   return (
-    <Box
+    <ImageBox
       ref={containerRef}
-      flexDirection="column"
       width={width}
       height={height}
+      alt={alt}
+      error={error}
+      loaded={!!imageOutput}
     >
-      {imageOutput ? (
-        imageOutput
-          .split("\n")
-          // biome-ignore lint/suspicious/noArrayIndexKey: static content, won't change
-          .map((line, idx) => <Text key={`${line}-${idx}`}>{line}</Text>)
-      ) : (
-        <Box flexDirection="column" alignItems="center" justifyContent="center">
-          {alt ? (
-            <Text color="gray">{alt}</Text>
-          ) : error ? (
-            <Text color="red">
-              X<Newline />
-              Load failed
-            </Text>
-          ) : (
-            <Text color="gray">Loading...</Text>
-          )}
-        </Box>
-      )}
-    </Box>
+      {imageOutput?.split("\n").map((line, idx) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static content, won't change
+        <Text key={`${line}-${idx}`}>{line}</Text>
+      ))}
+    </ImageBox>
   );
 }
 

--- a/src/components/image/Braille.tsx
+++ b/src/components/image/Braille.tsx
@@ -1,84 +1,29 @@
-import { Box, type DOMElement, measureElement, Newline, Text } from "ink";
-import React, { useEffect, useRef, useState } from "react";
+import { Box, Newline, Text } from "ink";
+import React, { useMemo } from "react";
+import { useImage } from "../../hooks/useImage.js";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import { renderBraille } from "../../renderers/braille.js";
-import {
-  calculateImageSize,
-  fetchImage,
-  getRawPixels,
-} from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
-/**
- * Braille Image Rendering Component
- *
- * Renders images using Unicode Braille patterns to create high-resolution monochrome representations.
- * Each Braille character can represent 8 pixels (2x4 grid), providing higher resolution than
- * other text-based rendering methods.
- *
- * Features:
- * - High resolution monochrome rendering (8 pixels per character)
- * - Uses Unicode Braille patterns (U+2800-U+28FF)
- * - Requires only Unicode support (no color needed)
- * - Good for detailed images and line art
- * - Works well for images with clear contrast
- *
- * Technical Details:
- * - Each Braille character represents a 2x4 pixel grid
- * - Uses luminance-based threshold for black/white conversion
- * - Handles transparency by treating transparent pixels as white
- * - Braille patterns are constructed using bit manipulation
- *
- * Braille Pattern Layout:
- * ```
- * 1 4
- * 2 5
- * 3 6
- * 7 8
- * ```
- *
- * @param props - Image rendering properties
- * @returns JSX element containing Braille pattern representation of the image
- */
 function BrailleImage(props: ImageProps) {
-  const [imageOutput, setImageOutput] = useState<string | null>(null);
-  const [hasError, setHasError] = useState<boolean>(false);
-  const containerRef = useRef<DOMElement | null>(null);
   const { src, width, height, alt, allowPartial } = props;
-  const [measuredWidth, setMeasuredWidth] = useState(0);
-  const [measuredHeight, setMeasuredHeight] = useState(0);
 
-  const needsMeasure = typeof width === "string" || typeof height === "string";
-  useEffect(() => {
-    if (!needsMeasure) return;
-    if (!containerRef.current) return;
+  const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
+    width,
+    height,
+  );
 
-    const { width: w, height: h } = measureElement(containerRef.current);
-    if (w > 0) setMeasuredWidth(w);
-    if (h > 0) setMeasuredHeight(h);
+  const { imageData, error } = useImage({
+    src,
+    pixelWidth: resolvedWidth * 2,
+    pixelHeight: resolvedHeight * 4,
+    mode: "pixels",
   });
 
-  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
-  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
-
-  useEffect(() => {
-    if (resolvedWidth === 0 || resolvedHeight === 0) return;
-
-    const generateImageOutput = async () => {
-      const image = await fetchImage(src, allowPartial);
-      if (!image) {
-        setHasError(true);
-        return;
-      }
-      setHasError(false);
-
-      image.resize({ w: resolvedWidth * 2, h: resolvedHeight * 4 });
-      const resizedImage = await getRawPixels(image);
-
-      const output = renderBraille(resizedImage);
-      setImageOutput(output);
-    };
-    generateImageOutput();
-  }, [src, resolvedWidth, resolvedHeight, allowPartial]);
+  const imageOutput = useMemo(() => {
+    if (!imageData) return null;
+    return renderBraille(imageData);
+  }, [imageData]);
 
   return (
     <Box
@@ -96,7 +41,7 @@ function BrailleImage(props: ImageProps) {
         <Box flexDirection="column" alignItems="center" justifyContent="center">
           {alt ? (
             <Text color="gray">{alt}</Text>
-          ) : hasError ? (
+          ) : error ? (
             <Text color="red">
               X<Newline />
               Load failed

--- a/src/components/image/Braille.tsx
+++ b/src/components/image/Braille.tsx
@@ -1,10 +1,10 @@
 import { Box, type DOMElement, measureElement, Newline, Text } from "ink";
 import React, { useEffect, useRef, useState } from "react";
+import { renderBraille } from "../../renderers/braille.js";
 import {
   calculateImageSize,
   fetchImage,
   getRawPixels,
-  type ImageOutputInfo,
 } from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
@@ -74,7 +74,7 @@ function BrailleImage(props: ImageProps) {
       image.resize({ w: resolvedWidth * 2, h: resolvedHeight * 4 });
       const resizedImage = await getRawPixels(image);
 
-      const output = await toBraille(resizedImage);
+      const output = renderBraille(resizedImage);
       setImageOutput(output);
     };
     generateImageOutput();
@@ -108,132 +108,6 @@ function BrailleImage(props: ImageProps) {
       )}
     </Box>
   );
-}
-
-/**
- * Converts image data to Braille pattern representation.
- *
- * This function processes the image by:
- * 1. Grouping pixels into 2x4 grids (8 pixels per Braille character)
- * 2. Converting each pixel to black or white based on luminance threshold
- * 3. Mapping the 8 pixels to corresponding Braille dot positions
- * 4. Constructing Unicode Braille characters using bit manipulation
- *
- * How Braille patterns work:
- * - Each character represents 8 dots in a 2x4 arrangement
- * - Dot positions are numbered 1-8 as shown in the component description
- * - A raised dot (1) represents a white/bright pixel
- * - A flat dot (0) represents a black/dark pixel
- * - Unicode range U+2800-U+28FF covers all 256 possible combinations
- *
- * Reference: https://en.wikipedia.org/wiki/Braille_Patterns#Identifying,_naming_and_ordering
- *
- * @param imageData - Raw image data from Jimp with buffer and metadata
- * @returns Promise resolving to string of Braille Unicode characters
- */
-async function toBraille(imageData: { data: Buffer; info: ImageOutputInfo }) {
-  const { data, info } = imageData;
-  const { width, height, channels } = info;
-
-  let result = "";
-  for (let y = 0; y < height - 3; y += 4) {
-    for (let x = 0; x < width - 1; x += 2) {
-      const dot1Index = (y * width + x) * channels;
-      const dot2Index = ((y + 1) * width + x) * channels;
-      const dot3Index = ((y + 2) * width + x) * channels;
-      const dot4Index = (y * width + x + 1) * channels;
-      const dot5Index = ((y + 1) * width + x + 1) * channels;
-      const dot6Index = ((y + 2) * width + x + 1) * channels;
-      const dot7Index = ((y + 3) * width + x) * channels;
-      const dot8Index = ((y + 3) * width + x + 1) * channels;
-
-      const getRgba = (index: number) => {
-        const r = data[index] as number;
-        const g = data[index + 1] as number;
-        const b = data[index + 2] as number;
-        const a = channels === 4 ? (data[index + 3] as number) : 1;
-        return { r, g, b, a };
-      };
-
-      const dot1 = rgbaToBlackOrWhite(getRgba(dot1Index));
-      const dot2 = rgbaToBlackOrWhite(getRgba(dot2Index));
-      const dot3 = rgbaToBlackOrWhite(getRgba(dot3Index));
-      const dot4 = rgbaToBlackOrWhite(getRgba(dot4Index));
-      const dot5 = rgbaToBlackOrWhite(getRgba(dot5Index));
-      const dot6 = rgbaToBlackOrWhite(getRgba(dot6Index));
-      const dot7 = rgbaToBlackOrWhite(getRgba(dot7Index));
-      const dot8 = rgbaToBlackOrWhite(getRgba(dot8Index));
-
-      const brailleChar = String.fromCharCode(
-        0x2800 +
-          (dot8 << 7) +
-          (dot7 << 6) +
-          (dot6 << 5) +
-          (dot5 << 4) +
-          (dot4 << 3) +
-          (dot3 << 2) +
-          (dot2 << 1) +
-          dot1,
-      );
-      result += brailleChar;
-    }
-    result += "\n";
-  }
-
-  return result;
-}
-
-/**
- * Converts RGBA pixel values to binary (black or white) representation.
- *
- * This function:
- * 1. Calculates perceived luminance using the relative luminance formula
- * 2. Adjusts for alpha transparency (transparent pixels become lighter)
- * 3. Applies a threshold to determine if the pixel should be represented as a raised Braille dot
- *
- * The luminance formula uses coefficients based on human eye sensitivity:
- * - Red: 21.26% (0.2126)
- * - Green: 71.52% (0.7152) - eyes are most sensitive to green
- * - Blue: 7.22% (0.0722)
- *
- * Alpha handling makes transparent pixels appear closer to white, which is
- * appropriate for typical terminal backgrounds.
- *
- * @param rgba - RGBA color values (0-255 range)
- * @returns 1 for white/light pixels (raised dot), 0 for black/dark pixels (flat dot)
- */
-function rgbaToBlackOrWhite({
-  r,
-  g,
-  b,
-  a,
-}: {
-  r: number;
-  g: number;
-  b: number;
-  a: number;
-}) {
-  // 1. Extract the RGBA components from the input string.
-  const red = r;
-  const green = g;
-  const blue = b;
-  // Jimp bitmap data stores alpha as 0-255, normalize to 0-1
-  const alpha = a / 255;
-
-  // 2. Calculate the perceived luminance using the formula for relative luminance (Y).
-  //    This formula is based on the sRGB color space and takes into account the human eye's sensitivity to different colors.
-  const luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue;
-
-  // 3. Apply the alpha value to the luminance.  This makes transparent colors closer to white.
-  const alphaAdjustedLuminance = luminance * alpha + 255 * (1 - alpha);
-
-  // 4. Determine whether to return "black" or "white" based on the luminance.
-  //    A threshold of 128 is commonly used to differentiate between dark and light colors.
-  if (alphaAdjustedLuminance > 128) {
-    return 1;
-  } else {
-    return 0;
-  }
 }
 
 export default BrailleImage;

--- a/src/components/image/HalfBlock.tsx
+++ b/src/components/image/HalfBlock.tsx
@@ -1,12 +1,13 @@
-import { Box, Newline, Text } from "ink";
+import { Text } from "ink";
 import React, { useMemo } from "react";
 import { useImage } from "../../hooks/useImage.js";
 import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import { renderHalfBlock } from "../../renderers/halfBlock.js";
+import ImageBox from "../ImageBox.js";
 import type { ImageProps } from "./protocol.js";
 
 function HalfBlockImage(props: ImageProps) {
-  const { src, width, height, alt, allowPartial } = props;
+  const { src, width, height, alt } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -26,32 +27,19 @@ function HalfBlockImage(props: ImageProps) {
   }, [imageData]);
 
   return (
-    <Box
+    <ImageBox
       ref={containerRef}
-      flexDirection="column"
       width={width}
       height={height}
+      alt={alt}
+      error={error}
+      loaded={!!imageOutput}
     >
-      {imageOutput ? (
-        imageOutput
-          .split("\n")
-          // biome-ignore lint/suspicious/noArrayIndexKey: static content, won't change
-          .map((line, idx) => <Text key={`${line}-${idx}`}>{line}</Text>)
-      ) : (
-        <Box flexDirection="column" alignItems="center" justifyContent="center">
-          {alt ? (
-            <Text color="gray">{alt}</Text>
-          ) : error ? (
-            <Text color="red">
-              X<Newline />
-              Load failed
-            </Text>
-          ) : (
-            <Text color="gray">{props.alt || "Loading..."}</Text>
-          )}
-        </Box>
-      )}
-    </Box>
+      {imageOutput?.split("\n").map((line, idx) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static content, won't change
+        <Text key={`${line}-${idx}`}>{line}</Text>
+      ))}
+    </ImageBox>
   );
 }
 

--- a/src/components/image/HalfBlock.tsx
+++ b/src/components/image/HalfBlock.tsx
@@ -1,11 +1,7 @@
-import chalk from "chalk";
 import { Box, type DOMElement, measureElement, Newline, Text } from "ink";
 import React, { useEffect, useRef, useState } from "react";
-import {
-  fetchImage,
-  getRawPixels,
-  type ImageOutputInfo,
-} from "../../utils/image.js";
+import { renderHalfBlock } from "../../renderers/halfBlock.js";
+import { fetchImage, getRawPixels } from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
 /**
@@ -66,7 +62,7 @@ function HalfBlockImage(props: ImageProps) {
       image.resize({ w: resolvedWidth, h: resolvedHeight * 2 });
       const resizedImage = await getRawPixels(image);
 
-      const output = await toHalfBlocks(resizedImage);
+      const output = renderHalfBlock(resizedImage);
       setImageOutput(output);
     };
     generateImageOutput();
@@ -100,62 +96,6 @@ function HalfBlockImage(props: ImageProps) {
       )}
     </Box>
   );
-}
-
-/** Unicode half-block character (▄) used for rendering */
-const HALF_BLOCK = "\u2584";
-
-/**
- * Converts image data to half-block representation.
- *
- * This function processes the image by:
- * 1. Iterating through pixels in pairs (top and bottom)
- * 2. Using the top pixel color as background
- * 3. Using the bottom pixel color as foreground
- * 4. Rendering a half-block character with these colors
- * 5. Handling transparency by using spaces for transparent pixels
- *
- * The half-block character (▄) fills the bottom half of the character cell,
- * so the background color shows through the top half, effectively displaying
- * two pixels per character position.
- *
- * Adapted from https://github.com/sindresorhus/terminal-image
- *
- * @param imageData - Raw image data from Jimp with buffer and metadata
- * @returns Promise resolving to formatted string with colored half-block characters
- */
-async function toHalfBlocks(imageData: {
-  data: Buffer;
-  info: ImageOutputInfo;
-}) {
-  const { data, info } = imageData;
-  const { width, height, channels } = info;
-
-  let result = "";
-  for (let y = 0; y < height - 1; y += 2) {
-    for (let x = 0; x < width; x++) {
-      const topPixelIndex = (y * width + x) * channels;
-      const bottomPixelIndex = ((y + 1) * width + x) * channels;
-
-      const r = data[topPixelIndex] as number;
-      const g = data[topPixelIndex + 1] as number;
-      const b = data[topPixelIndex + 2] as number;
-      const a = channels === 4 ? (data[topPixelIndex + 3] as number) : 255;
-
-      const r2 = data[bottomPixelIndex] as number;
-      const g2 = data[bottomPixelIndex + 1] as number;
-      const b2 = data[bottomPixelIndex + 2] as number;
-
-      result +=
-        a === 0
-          ? chalk.reset(" ")
-          : chalk.bgRgb(r, g, b).rgb(r2, g2, b2)(HALF_BLOCK);
-    }
-
-    result += "\n";
-  }
-
-  return result;
 }
 
 export default HalfBlockImage;

--- a/src/components/image/HalfBlock.tsx
+++ b/src/components/image/HalfBlock.tsx
@@ -1,72 +1,29 @@
-import { Box, type DOMElement, measureElement, Newline, Text } from "ink";
-import React, { useEffect, useRef, useState } from "react";
+import { Box, Newline, Text } from "ink";
+import React, { useMemo } from "react";
+import { useImage } from "../../hooks/useImage.js";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import { renderHalfBlock } from "../../renderers/halfBlock.js";
-import { fetchImage, getRawPixels } from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
-/**
- * Half-Block Image Rendering Component
- *
- * Renders images using Unicode half-block characters (▄) with colored backgrounds and foregrounds.
- * This method provides higher resolution than ASCII art by utilizing both the character color
- * and background color to represent two pixels per character cell.
- *
- * Features:
- * - Higher resolution than ASCII (2 pixels per character)
- * - Full color support using terminal RGB colors
- * - Requires Unicode and color support
- * - Good balance between quality and compatibility
- *
- * Technical Details:
- * - Uses Unicode half-block character (U+2584 ▄)
- * - Top pixel represented by background color
- * - Bottom pixel represented by foreground color
- * - Requires terminal color and Unicode support
- * - Processes images in pairs of vertical pixels
- *
- * @param props - Image rendering properties
- * @returns JSX element containing half-block representation of the image
- */
 function HalfBlockImage(props: ImageProps) {
-  const [imageOutput, setImageOutput] = useState<string | null>(null);
-  const [hasError, setHasError] = useState<boolean>(false);
-  const containerRef = useRef<DOMElement | null>(null);
   const { src, width, height, alt, allowPartial } = props;
-  const [measuredWidth, setMeasuredWidth] = useState(0);
-  const [measuredHeight, setMeasuredHeight] = useState(0);
 
-  const needsMeasure = typeof width === "string" || typeof height === "string";
-  useEffect(() => {
-    if (!needsMeasure) return;
-    if (!containerRef.current) return;
+  const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
+    width,
+    height,
+  );
 
-    const { width: w, height: h } = measureElement(containerRef.current);
-    if (w > 0) setMeasuredWidth(w);
-    if (h > 0) setMeasuredHeight(h);
+  const { imageData, error } = useImage({
+    src,
+    pixelWidth: resolvedWidth,
+    pixelHeight: resolvedHeight * 2,
+    mode: "pixels",
   });
 
-  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
-  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
-
-  useEffect(() => {
-    if (resolvedWidth === 0 || resolvedHeight === 0) return;
-
-    const generateImageOutput = async () => {
-      const image = await fetchImage(src, allowPartial);
-      if (!image) {
-        setHasError(true);
-        return;
-      }
-      setHasError(false);
-
-      image.resize({ w: resolvedWidth, h: resolvedHeight * 2 });
-      const resizedImage = await getRawPixels(image);
-
-      const output = renderHalfBlock(resizedImage);
-      setImageOutput(output);
-    };
-    generateImageOutput();
-  }, [src, resolvedWidth, resolvedHeight, allowPartial]);
+  const imageOutput = useMemo(() => {
+    if (!imageData) return null;
+    return renderHalfBlock(imageData);
+  }, [imageData]);
 
   return (
     <Box
@@ -84,7 +41,7 @@ function HalfBlockImage(props: ImageProps) {
         <Box flexDirection="column" alignItems="center" justifyContent="center">
           {alt ? (
             <Text color="gray">{alt}</Text>
-          ) : hasError ? (
+          ) : error ? (
             <Text color="red">
               X<Newline />
               Load failed

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -1,235 +1,50 @@
-import {
-  Box,
-  type DOMElement,
-  measureElement,
-  Newline,
-  Text,
-  useStdout,
-} from "ink";
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Box, Newline, Text, useStdout } from "ink";
+import React, { useMemo } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import useBackgroundColor from "../../hooks/useBackgroundColor.js";
+import { useDirectRenderer } from "../../hooks/useDirectRenderer.js";
+import { useImage } from "../../hooks/useImage.js";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import usePosition from "../../hooks/usePosition.js";
 import { renderITerm2 } from "../../renderers/iterm2.js";
-import { cursorForward, cursorUp } from "../../utils/ansiEscapes.js";
-import bgColorize from "../../utils/bgColorize.js";
-import {
-  calculateImageSize,
-  fetchImage,
-  getPngBuffer,
-} from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
-/**
- * ITerm2 Image Rendering Component
- *
- * Displays images using the ITerm2 graphics protocol, providing the highest quality
- * image rendering in supported terminals. ITerm2 is a bitmap graphics format that
- * can display true color images at full resolution.
- *
- * Features:
- * - Highest quality image rendering (true color, full resolution)
- * - Supports all image formats
- * - Requires specific terminal support (VT340+, xterm, iTerm2, etc.)
- * - Direct pixel-to-pixel rendering
- *
- * Technical Details:
- * - Uses the ITerm2 graphics protocol
- * - Renders directly to terminal using escape sequences
- * - Bypasses Ink's normal rendering pipeline for control over image position
- * - Requires careful cursor management and cleanup
- *
- * **EXPERIMENTAL COMPONENT WARNING:**
- * This component does not follow React/Ink's normal rendering lifecycle.
- * It implements custom rendering logic that writes directly to the terminal.
- * While designed to be as React-compatible as possible, you may experience:
- * - Rendering flicker
- * - Cursor positioning issues
- * - Cleanup problems on component unmount
- *
- * How it works:
- * 1. A Box component reserves space in the layout
- * 2. Image is fetched and converted to ITerm2 format
- * 3. useEffect hook renders image directly to terminal after each Ink render
- * 4. Previous image is cleared before rendering new content
- * 5. Cleanup occurs on component unmount or re-render
- * 6. Cleanup will not be performed when application terminates (so the rendered image is preserved in its location)
- *
- * @param props - Image rendering properties
- * @returns JSX element that manages ITerm2 image display
- */
 function ITerm2Image(props: ImageProps) {
-  const [imageOutput, setImageOutput] = useState<string | undefined>(undefined);
-  const [hasError, setHasError] = useState<boolean>(false);
+  const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const containerRef = useRef<DOMElement | null>(null);
+  const { src, width, height, alt, allowPartial } = props;
+
+  const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
+    width,
+    height,
+  );
+
   const componentPosition = usePosition(containerRef);
   const inheritedBackgroundColor = useBackgroundColor(containerRef);
-  const terminalInfo = useTerminalInfo();
-  const shouldCleanupRef = useRef<boolean>(true);
-  const { src, width, height, alt, allowPartial } = props;
-  const [measuredWidth, setMeasuredWidth] = useState(0);
-  const [measuredHeight, setMeasuredHeight] = useState(0);
 
-  const needsMeasure = typeof width === "string" || typeof height === "string";
-  useEffect(() => {
-    if (!needsMeasure) return;
-    if (!containerRef.current) return;
+  const pixelWidth = resolvedWidth * (terminalInfo?.cellWidth ?? 0);
+  const pixelHeight = resolvedHeight * (terminalInfo?.cellHeight ?? 0);
 
-    const { width: w, height: h } = measureElement(containerRef.current);
-    if (w > 0) setMeasuredWidth(w);
-    if (h > 0) setMeasuredHeight(h);
+  const { imageData, error } = useImage({
+    src,
+    pixelWidth,
+    pixelHeight,
+    mode: "png",
   });
 
-  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
-  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
+  const imageOutput = useMemo(() => {
+    if (!imageData) return undefined;
+    return renderITerm2(imageData, { width: pixelWidth, height: pixelHeight });
+  }, [imageData, pixelWidth, pixelHeight]);
 
-  /**
-   * Main effect for image processing and ITerm2 conversion.
-   *
-   * This effect:
-   * 1. Fetches and processes the source image
-   * 2. Calculates appropriate sizing based on terminal dimensions
-   * 3. Resizes image to fit within the component's allocated space
-   * 4. Ensures alpha channel is present (required by node-iTerm2)
-   * 5. Converts processed image data to ITerm2 format
-   * 6. Tracks actual size in terminal cells for cleanup purposes
-   */
-  useEffect(() => {
-    if (resolvedWidth === 0 || resolvedHeight === 0) return;
-    if (!terminalInfo) return;
-
-    const generateImageOutput = async () => {
-      const image = await fetchImage(src, allowPartial);
-      if (!image) {
-        setHasError(true);
-        return;
-      }
-      setHasError(false);
-
-      image.resize({
-        w: resolvedWidth * terminalInfo.cellWidth,
-        h: resolvedHeight * terminalInfo.cellHeight,
-      });
-      const resizedImage = await getPngBuffer(image);
-
-      const output = renderITerm2(resizedImage, {
-        width: resolvedWidth * terminalInfo.cellWidth,
-        height: resolvedHeight * terminalInfo.cellHeight,
-      });
-      setImageOutput(output);
-    };
-    generateImageOutput();
-  }, [src, resolvedWidth, resolvedHeight, terminalInfo, allowPartial]);
-
-  /**
-   * Critical rendering effect for ITerm2 image display.
-   *
-   * This effect runs after every re-render to display the ITerm2 image because
-   * Ink overwrites the terminal content with each render cycle. This is a
-   * necessary workaround for the current Ink architecture.
-   *
-   * Process:
-   * 1. Validates that image and position data are available
-   * 2. Checks if the image would be visible within terminal bounds
-   * 3. Sets up process exit handlers for cleanup
-   * 4. Positions cursor to the correct location
-   * 5. Writes ITerm2 data directly to stdout
-   * 6. Restores cursor position
-   * 7. Returns cleanup function for previous render cleanup
-   *
-   * Cursor Management:
-   * - Moves cursor up to component position
-   * - Moves cursor right to correct column
-   * - Writes image data
-   * - Moves cursor back down to original position
-   *
-   * Cleanup Strategy:
-   * - Tracks previous render bounding box
-   * - Clears previous image by writing spaces
-   * - Handles process exit gracefully
-   *
-   * TODO: This may change when Ink implements incremental rendering
-   */
-  useLayoutEffect(() => {
-    if (!imageOutput) return;
-    if (!componentPosition) return;
-    if (
-      stdout.rows - componentPosition.appHeight + componentPosition.row < 0 ||
-      componentPosition.col > stdout.columns
-    )
-      return;
-
-    function onExit() {
-      shouldCleanupRef.current = false;
-    }
-    function onSigInt() {
-      shouldCleanupRef.current = false;
-      process.exit();
-    }
-    process.on("exit", onExit);
-    process.on("SIGINT", onSigInt);
-    process.on("SIGTERM", onSigInt);
-
-    let previousRenderBoundingBox:
-      | { row: number; col: number; width: number; height: number }
-      | undefined;
-    const renderTimeout = setTimeout(() => {
-      stdout.write("\x1b7"); // Save cursor position
-      stdout.write(
-        cursorUp(componentPosition.appHeight - componentPosition.row, {
-          appHeight: componentPosition.appHeight,
-          terminalHeight: stdout.rows,
-        }),
-      );
-      stdout.write("\r");
-      stdout.write(cursorForward(componentPosition.col));
-      stdout.write(imageOutput);
-      stdout.write("\x1b8"); // Restore cursor position
-
-      previousRenderBoundingBox = {
-        row: stdout.rows - componentPosition.appHeight + componentPosition.row,
-        col: componentPosition.col,
-        width: resolvedWidth,
-        height: resolvedHeight,
-      };
-    }, 100); // Delay to allow Ink/terminal to finish its render
-
-    return () => {
-      process.removeListener("exit", onExit);
-      process.removeListener("SIGINT", onSigInt);
-      process.removeListener("SIGTERM", onSigInt);
-
-      if (!shouldCleanupRef.current) return;
-      clearTimeout(renderTimeout);
-      // If we never rendered the image, nothing to clean up
-      if (!previousRenderBoundingBox) return;
-
-      stdout.write("\x1b7"); // Save cursor position
-      stdout.write(
-        cursorUp(componentPosition.appHeight - componentPosition.row, {
-          appHeight: componentPosition.appHeight,
-          terminalHeight: stdout.rows,
-        }),
-      );
-      for (let i = 0; i < previousRenderBoundingBox.height; i++) {
-        stdout.write("\r");
-        stdout.write(cursorForward(previousRenderBoundingBox.col));
-        if (inheritedBackgroundColor) {
-          stdout.write(
-            bgColorize(
-              " ".repeat(previousRenderBoundingBox.width),
-              inheritedBackgroundColor,
-            ),
-          );
-        } else {
-          stdout.write(" ".repeat(previousRenderBoundingBox.width));
-        }
-        stdout.write("\n");
-      }
-      stdout.write("\x1b8"); // Restore cursor position
-    };
-    // }, [imageOutput, ...Object.values(componentPosition)]);
+  useDirectRenderer({
+    enabled: !!imageOutput && !!componentPosition,
+    imageOutput: imageOutput ?? "",
+    position: componentPosition,
+    stdout,
+    width: resolvedWidth,
+    height: resolvedHeight,
+    backgroundColor: inheritedBackgroundColor,
   });
 
   return (
@@ -247,7 +62,7 @@ function ITerm2Image(props: ImageProps) {
         <Box flexDirection="column" alignItems="center" justifyContent="center">
           {alt ? (
             <Text color="gray">{alt}</Text>
-          ) : hasError ? (
+          ) : error ? (
             <Text color="red">
               X<Newline />
               Load failed

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -10,13 +10,13 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import useBackgroundColor from "../../hooks/useBackgroundColor.js";
 import usePosition from "../../hooks/usePosition.js";
+import { renderITerm2 } from "../../renderers/iterm2.js";
 import { cursorForward, cursorUp } from "../../utils/ansiEscapes.js";
 import bgColorize from "../../utils/bgColorize.js";
 import {
   calculateImageSize,
   fetchImage,
   getPngBuffer,
-  type ImageOutputInfo,
 } from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
@@ -113,7 +113,7 @@ function ITerm2Image(props: ImageProps) {
       });
       const resizedImage = await getPngBuffer(image);
 
-      const output = toITerm2(resizedImage, {
+      const output = renderITerm2(resizedImage, {
         width: resolvedWidth * terminalInfo.cellWidth,
         height: resolvedHeight * terminalInfo.cellHeight,
       });
@@ -259,37 +259,6 @@ function ITerm2Image(props: ImageProps) {
       )}
     </Box>
   );
-}
-
-/**
- * Converts processed image data to ITerm2 format.
- *
- * This function takes raw RGBA image data from Jimp and converts it to
- * the ITerm2 graphics format using the node-iTerm2 library. The resulting
- * string contains escape sequences that can be written directly to a
- * terminal that supports ITerm2 graphics.
- *
- * @note We do not use auto width and height because we might adjust it based on scale factor
- *
- * @param imageData - Raw image data with buffer and metadata from Jimp
- * @returns ITerm2-formatted string
- */
-function toITerm2(
-  imageData: { data: Buffer; info: ImageOutputInfo },
-  options: { width: number; height: number },
-) {
-  const { data, info } = imageData;
-  const { width, height } = options;
-
-  const iTerm2Data =
-    "\x1b]1337;File=" +
-    `size=${info.size};` +
-    `width=${width}px;height=${height}px;` +
-    `preserveAspectRatio=1;` +
-    `inline=1:` +
-    data.toString("base64") +
-    "\x07";
-  return iTerm2Data;
 }
 
 export default ITerm2Image;

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -1,4 +1,4 @@
-import { Box, Newline, Text, useStdout } from "ink";
+import { useStdout } from "ink";
 import React, { useMemo } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import useBackgroundColor from "../../hooks/useBackgroundColor.js";
@@ -7,12 +7,13 @@ import { useImage } from "../../hooks/useImage.js";
 import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import usePosition from "../../hooks/usePosition.js";
 import { renderITerm2 } from "../../renderers/iterm2.js";
+import ImageBox from "../ImageBox.js";
 import type { ImageProps } from "./protocol.js";
 
 function ITerm2Image(props: ImageProps) {
   const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const { src, width, height, alt, allowPartial } = props;
+  const { src, width, height, alt } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -48,31 +49,14 @@ function ITerm2Image(props: ImageProps) {
   });
 
   return (
-    <Box
+    <ImageBox
       ref={containerRef}
-      flexDirection="column"
       width={width}
       height={height}
-    >
-      {imageOutput ? (
-        <Text color="gray" wrap="wrap">
-          {alt ?? "Loading..."}
-        </Text>
-      ) : (
-        <Box flexDirection="column" alignItems="center" justifyContent="center">
-          {alt ? (
-            <Text color="gray">{alt}</Text>
-          ) : error ? (
-            <Text color="red">
-              X<Newline />
-              Load failed
-            </Text>
-          ) : (
-            <Text color="gray">"Loading..."</Text>
-          )}
-        </Box>
-      )}
-    </Box>
+      alt={alt}
+      error={error}
+      loaded={!!imageOutput}
+    />
   );
 }
 

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -1,4 +1,4 @@
-import { Box, Newline, Text, useStdout } from "ink";
+import { useStdout } from "ink";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import { useImage } from "../../hooks/useImage.js";
@@ -11,12 +11,13 @@ import {
 } from "../../renderers/kitty.js";
 import { cursorForward, cursorUp } from "../../utils/ansiEscapes.js";
 import generateKittyId from "../../utils/generateKittyId.js";
+import ImageBox from "../ImageBox.js";
 import type { ImageProps } from "./protocol.js";
 
 function KittyImage(props: ImageProps) {
   const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const { src, width, height, alt, allowPartial } = props;
+  const { src, width, height, alt } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -101,31 +102,14 @@ function KittyImage(props: ImageProps) {
   }, [imageId, onExit, onSigInt, stdout.write]);
 
   return (
-    <Box
+    <ImageBox
       ref={containerRef}
-      flexDirection="column"
       width={width}
       height={height}
-    >
-      {imageId ? (
-        <Text color="gray" wrap="wrap">
-          {alt ?? "Loading..."}
-        </Text>
-      ) : (
-        <Box flexDirection="column" alignItems="center" justifyContent="center">
-          {alt ? (
-            <Text color="gray">{alt}</Text>
-          ) : error ? (
-            <Text color="red">
-              X<Newline />
-              Load failed
-            </Text>
-          ) : (
-            <Text color="gray">{props.alt || "Loading..."}</Text>
-          )}
-        </Box>
-      )}
-    </Box>
+      alt={alt}
+      error={error}
+      loaded={!!imageId}
+    />
   );
 }
 

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -4,6 +4,7 @@ import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import { useImage } from "../../hooks/useImage.js";
 import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import usePosition from "../../hooks/usePosition.js";
+import { defaultVisibility } from "../../hooks/useVisibility.js";
 import {
   makeKittyDeletion,
   makeKittyPlacement,
@@ -55,8 +56,8 @@ function KittyImage(props: ImageProps) {
     if (!imageId) return;
     if (!componentPosition) return;
     if (
-      stdout.rows - componentPosition.appHeight + componentPosition.row < 0 ||
-      componentPosition.col > stdout.columns
+      defaultVisibility(componentPosition, stdout.rows, stdout.columns) !==
+      "full"
     ) {
       return;
     }

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -1,13 +1,8 @@
-import {
-  Box,
-  type DOMElement,
-  measureElement,
-  Newline,
-  Text,
-  useStdout,
-} from "ink";
+import { Box, Newline, Text, useStdout } from "ink";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
+import { useImage } from "../../hooks/useImage.js";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import usePosition from "../../hooks/usePosition.js";
 import {
   makeKittyDeletion,
@@ -16,158 +11,45 @@ import {
 } from "../../renderers/kitty.js";
 import { cursorForward, cursorUp } from "../../utils/ansiEscapes.js";
 import generateKittyId from "../../utils/generateKittyId.js";
-import { calculateImageSize, fetchImage } from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
-/**
- * Kitty Image Rendering Component
- *
- * Displays images using the Kitty terminal graphics protocol, providing the highest quality
- * image rendering in supported terminals. Kitty is a bitmap graphics format that
- * can display true color images at full resolution.
- *
- * Features:
- * - Highest quality image rendering (true color, full resolution)
- * - Supports all image formats
- * - Requires specific terminal support (VT340+, xterm, iTerm2, etc.)
- * - Direct pixel-to-pixel rendering
- *
- * Technical Details:
- * - Uses the Kitty graphics protocol
- * - Renders directly to terminal using escape sequences
- * - Bypasses Ink's normal rendering pipeline for control over image position
- * - Requires careful cursor management
- * - More performant cleanup logic than sixel and iTerm2
- *
- * **EXPERIMENTAL COMPONENT WARNING:**
- * This component does not follow React/Ink's normal rendering lifecycle.
- * It implements custom rendering logic that writes directly to the terminal.
- * While designed to be as React-compatible as possible, you may experience:
- * - Rendering flicker
- * - Cursor positioning issues
- * - Cleanup problems on component unmount
- *
- * How it works:
- * 1. A Box component reserves space in the layout
- * 2. Image is fetched and converted to Kitty format
- * 3. useEffect hook renders image directly to terminal after each Ink render
- * 4. Previous image is cleared before rendering new content
- * 5. Cleanup occurs on component unmount or re-render
- * 6. Cleanup will not be performed when application terminates (so the rendered image is preserved in its location)
- *
- * @param props - Image rendering properties
- * @returns JSX element that manages Kitty image display
- */
 function KittyImage(props: ImageProps) {
-  const [imageId, setImageId] = useState<number | undefined>(undefined);
-  const [hasError, setHasError] = useState<boolean>(false);
-  const { stdout } = useStdout();
-  const containerRef = useRef<DOMElement | null>(null);
-  const componentPosition = usePosition(containerRef);
   const terminalInfo = useTerminalInfo();
-  const shouldCleanupRef = useRef<boolean>(true);
+  const { stdout } = useStdout();
   const { src, width, height, alt, allowPartial } = props;
-  const [measuredWidth, setMeasuredWidth] = useState(0);
-  const [measuredHeight, setMeasuredHeight] = useState(0);
 
-  // TODO: If we upgrade to Ink 6 we will need to deal with Box background colors when rendering/cleaning up
-  // const inheritedBackgroundColor = useContext(backgroundContext);
+  const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
+    width,
+    height,
+  );
 
-  const needsMeasure = typeof width === "string" || typeof height === "string";
-  useEffect(() => {
-    if (!needsMeasure) return;
-    if (!containerRef.current) return;
+  const componentPosition = usePosition(containerRef);
 
-    const { width: w, height: h } = measureElement(containerRef.current);
-    if (w > 0) setMeasuredWidth(w);
-    if (h > 0) setMeasuredHeight(h);
+  const pixelWidth = resolvedWidth * (terminalInfo?.cellWidth ?? 0);
+  const pixelHeight = resolvedHeight * (terminalInfo?.cellHeight ?? 0);
+
+  const { imageData, error } = useImage({
+    src,
+    pixelWidth,
+    pixelHeight,
+    mode: "png",
   });
 
-  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
-  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
+  const [imageId, setImageId] = useState<number | undefined>(undefined);
+  const shouldCleanupRef = useRef(true);
 
-  /**
-   * Main effect for image processing and Kitty conversion.
-   *
-   * This effect:
-   * 1. Fetches and processes the source image
-   * 2. Calculates appropriate sizing based on terminal dimensions
-   * 3. Resizes image to fit within the component's allocated space
-   * 4. Transfers image data to the terminal using Kitty protocol
-   */
   useEffect(() => {
-    if (resolvedWidth === 0 || resolvedHeight === 0) return;
-    if (!terminalInfo) return;
+    if (!imageData) return;
 
-    const generateImageOutput = async () => {
-      const image = await fetchImage(src, allowPartial);
-      if (!image) {
-        setHasError(true);
-        return;
-      }
-      setHasError(false);
+    const id = generateKittyId();
+    const base64Data = imageData.data.toString("base64");
+    const chunks = makeKittyTransmitChunks(id, base64Data);
+    for (const chunk of chunks) {
+      stdout.write(chunk);
+    }
+    setImageId(id);
+  }, [imageData, stdout.write]);
 
-      image.resize({
-        w: resolvedWidth * terminalInfo.cellWidth,
-        h: resolvedHeight * terminalInfo.cellHeight,
-      });
-
-      try {
-        const imageId = generateKittyId();
-
-        const data = await image.getBuffer("image/png");
-        const base64Data = data.toString("base64");
-
-        const chunks = makeKittyTransmitChunks(imageId, base64Data);
-        for (const chunk of chunks) {
-          stdout.write(chunk);
-        }
-
-        // Set image ID only after all data are sent
-        setImageId(imageId);
-      } catch {
-        setHasError(true);
-        return;
-      }
-    };
-    generateImageOutput();
-  }, [
-    src,
-    resolvedWidth,
-    resolvedHeight,
-    terminalInfo,
-    allowPartial,
-    stdout.write,
-  ]);
-
-  /**
-   * Critical rendering effect for Kitty image display.
-   *
-   * This effect runs after every re-render to display the Kitty image because
-   * Ink overwrites the terminal content with each render cycle. This is a
-   * necessary workaround for the current Ink architecture.
-   *
-   * Process:
-   * 1. Validates that image and position data are available
-   * 2. Positions cursor to the correct location
-   * 3. Tells terminal to display the Kitty image at that position
-   * 4. Restores cursor position
-   *
-   * Cursor Management:
-   * - Moves cursor up to component position
-   * - Moves cursor right to correct column
-   * - Writes image data
-   * - Moves cursor back down to original position
-   *
-   * TODO: This may change when Ink implements incremental rendering
-   */
-  const onExit = useCallback(() => {
-    shouldCleanupRef.current = false;
-  }, []);
-  const onSigInt = useCallback(() => {
-    shouldCleanupRef.current = false;
-    process.exit();
-  }, []);
   useEffect(() => {
     if (!imageId) return;
     if (!componentPosition) return;
@@ -178,10 +60,7 @@ function KittyImage(props: ImageProps) {
       return;
     }
 
-    // NOTE: technically we don't need to save/restore cursor position
-    // assuming that the terminal implements the kitty protocol correctly
-    // but some terminals do not respect the 'C=1' parameter
-    stdout.write("\x1b7"); // Save cursor position
+    stdout.write("\x1b7");
     stdout.write(
       cursorUp(componentPosition.appHeight - componentPosition.row, {
         appHeight: componentPosition.appHeight,
@@ -191,17 +70,20 @@ function KittyImage(props: ImageProps) {
     stdout.write("\r");
     stdout.write(cursorForward(componentPosition.col));
 
-    const placementId = 1;
-    stdout.write(makeKittyPlacement(imageId, placementId));
+    stdout.write(makeKittyPlacement(imageId, 1));
 
-    stdout.write("\x1b8"); // Restore cursor position
-
-    // We do not clean up on rerenders because
-    // kitty manages replacing images with the
-    // same image id and placement ID without any flicker
+    stdout.write("\x1b8");
   });
 
-  // Cleanup effect to remove Kitty image on unmount or image change only
+  const onExit = useCallback(() => {
+    shouldCleanupRef.current = false;
+  }, []);
+
+  const onSigInt = useCallback(() => {
+    shouldCleanupRef.current = false;
+    process.exit();
+  }, []);
+
   useEffect(() => {
     process.on("exit", onExit);
     process.on("SIGINT", onSigInt);
@@ -216,7 +98,7 @@ function KittyImage(props: ImageProps) {
 
       stdout.write(makeKittyDeletion(imageId));
     };
-  }, [imageId, stdout, onExit, onSigInt]);
+  }, [imageId, onExit, onSigInt, stdout.write]);
 
   return (
     <Box
@@ -233,7 +115,7 @@ function KittyImage(props: ImageProps) {
         <Box flexDirection="column" alignItems="center" justifyContent="center">
           {alt ? (
             <Text color="gray">{alt}</Text>
-          ) : hasError ? (
+          ) : error ? (
             <Text color="red">
               X<Newline />
               Load failed

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -39,6 +39,7 @@ function KittyImage(props: ImageProps) {
 
   const [imageId, setImageId] = useState<number | undefined>(undefined);
   const shouldCleanupRef = useRef(true);
+  const wasPlacedRef = useRef(false);
 
   useEffect(() => {
     if (!imageData) return;
@@ -55,10 +56,15 @@ function KittyImage(props: ImageProps) {
   useEffect(() => {
     if (!imageId) return;
     if (!componentPosition) return;
+
     if (
       defaultVisibility(componentPosition, stdout.rows, stdout.columns) !==
       "full"
     ) {
+      if (wasPlacedRef.current) {
+        stdout.write(makeKittyDeletion(imageId, 1));
+        wasPlacedRef.current = false;
+      }
       return;
     }
 
@@ -75,6 +81,8 @@ function KittyImage(props: ImageProps) {
     stdout.write(makeKittyPlacement(imageId, 1));
 
     stdout.write("\x1b8");
+
+    wasPlacedRef.current = true;
   });
 
   const onExit = useCallback(() => {
@@ -98,6 +106,8 @@ function KittyImage(props: ImageProps) {
       if (!shouldCleanupRef.current) return;
       if (!imageId) return;
 
+      // We always delete during unmount regardless of whether the image is placed
+      // in order to remove the image data from the terminal
       stdout.write(makeKittyDeletion(imageId));
     };
   }, [imageId, onExit, onSigInt, stdout.write]);

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -8,8 +8,12 @@ import {
 } from "ink";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
-// import { backgroundContext } from "ink";
 import usePosition from "../../hooks/usePosition.js";
+import {
+  makeKittyDeletion,
+  makeKittyPlacement,
+  makeKittyTransmitChunks,
+} from "../../renderers/kitty.js";
 import { cursorForward, cursorUp } from "../../utils/ansiEscapes.js";
 import generateKittyId from "../../utils/generateKittyId.js";
 import { calculateImageSize, fetchImage } from "../../utils/image.js";
@@ -112,26 +116,12 @@ function KittyImage(props: ImageProps) {
         const imageId = generateKittyId();
 
         const data = await image.getBuffer("image/png");
-        const chunkSize = 4096; // Kitty protocol pixel data max chunk size
         const base64Data = data.toString("base64");
 
-        const firstChunk = base64Data.slice(0, chunkSize);
-        // f=100: transmit png data; t=d: direct transfer; i=image-id;
-        // m=1: more chunks follow; q=2: suppress terminal response
-        stdout.write(
-          `\x1b_Gf=100,t=d,i=${imageId},m=1,q=2;${firstChunk}\x1b\\`,
-        );
-        let bufferOffset = chunkSize;
-        while (bufferOffset < base64Data.length - chunkSize) {
-          const chunk = base64Data.slice(
-            bufferOffset,
-            bufferOffset + chunkSize,
-          );
-          bufferOffset += chunkSize;
-          stdout.write(`\x1b_Gm=1,q=2;${chunk}\x1b\\`);
+        const chunks = makeKittyTransmitChunks(imageId, base64Data);
+        for (const chunk of chunks) {
+          stdout.write(chunk);
         }
-        const lastChunk = base64Data.slice(bufferOffset);
-        stdout.write(`\x1b_Gm=0,q=2;${lastChunk}\x1b\\`);
 
         // Set image ID only after all data are sent
         setImageId(imageId);
@@ -201,10 +191,8 @@ function KittyImage(props: ImageProps) {
     stdout.write("\r");
     stdout.write(cursorForward(componentPosition.col));
 
-    const placementId = 1; // We only have one image per component instance
-    // a=p: place image; i=image-id; p=placement-id; C=1: do not move cursor;
-    // q=2: supress terminal response (don't write to stdin)
-    stdout.write(`\x1b_Ga=p,i=${imageId},p=${placementId},C=1,q=2\x1b\\`);
+    const placementId = 1;
+    stdout.write(makeKittyPlacement(imageId, placementId));
 
     stdout.write("\x1b8"); // Restore cursor position
 
@@ -226,8 +214,7 @@ function KittyImage(props: ImageProps) {
       if (!shouldCleanupRef.current) return;
       if (!imageId) return;
 
-      // a=d: delete image; d=I: remove image data from storage; i=image-id
-      stdout.write(`\x1b_Ga=d,d=I,i=${imageId}\x1b\\`);
+      stdout.write(makeKittyDeletion(imageId));
     };
   }, [imageId, stdout, onExit, onSigInt]);
 

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -1,232 +1,50 @@
-import {
-  Box,
-  type DOMElement,
-  measureElement,
-  Newline,
-  Text,
-  useStdout,
-} from "ink";
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Box, Newline, Text, useStdout } from "ink";
+import React, { useMemo } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import useBackgroundColor from "../../hooks/useBackgroundColor.js";
+import { useDirectRenderer } from "../../hooks/useDirectRenderer.js";
+import { useImage } from "../../hooks/useImage.js";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import usePosition from "../../hooks/usePosition.js";
 import { renderSixel } from "../../renderers/sixel.js";
-import { cursorForward, cursorUp } from "../../utils/ansiEscapes.js";
-import bgColorize from "../../utils/bgColorize.js";
-import {
-  calculateImageSize,
-  fetchImage,
-  getRawPixels,
-} from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
-/**
- * Sixel Image Rendering Component
- *
- * Displays images using the Sixel graphics protocol, providing the highest quality
- * image rendering in supported terminals. Sixel is a bitmap graphics format that
- * can display true color images at full resolution.
- *
- * Features:
- * - Highest quality image rendering (true color, full resolution)
- * - Supports all image formats
- * - Requires specific terminal support (VT340+, xterm, iTerm2, etc.)
- * - Direct pixel-to-pixel rendering
- *
- * Technical Details:
- * - Uses the Sixel graphics protocol
- * - Renders directly to terminal using escape sequences
- * - Bypasses Ink's normal rendering pipeline for control over image position
- * - Requires careful cursor management and cleanup
- *
- * **EXPERIMENTAL COMPONENT WARNING:**
- * This component does not follow React/Ink's normal rendering lifecycle.
- * It implements custom rendering logic that writes directly to the terminal.
- * While designed to be as React-compatible as possible, you may experience:
- * - Rendering flicker
- * - Cursor positioning issues
- * - Cleanup problems on component unmount
- *
- * How it works:
- * 1. A Box component reserves space in the layout
- * 2. Image is fetched and converted to Sixel format
- * 3. useEffect hook renders image directly to terminal after each Ink render
- * 4. Previous image is cleared before rendering new content
- * 5. Cleanup occurs on component unmount or re-render
- * 6. Cleanup will not be performed when application terminates (so the rendered image is preserved in its location)
- *
- * @param props - Image rendering properties
- * @returns JSX element that manages Sixel image display
- */
 function SixelImage(props: ImageProps) {
-  const [imageOutput, setImageOutput] = useState<string | undefined>(undefined);
-  const [hasError, setHasError] = useState<boolean>(false);
+  const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const containerRef = useRef<DOMElement | null>(null);
+  const { src, width, height, alt, allowPartial } = props;
+
+  const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
+    width,
+    height,
+  );
+
   const componentPosition = usePosition(containerRef);
   const inheritedBackgroundColor = useBackgroundColor(containerRef);
-  const terminalInfo = useTerminalInfo();
-  const shouldCleanupRef = useRef<boolean>(true);
-  const { src, width, height, alt, allowPartial } = props;
-  const [measuredWidth, setMeasuredWidth] = useState(0);
-  const [measuredHeight, setMeasuredHeight] = useState(0);
 
-  const needsMeasure = typeof width === "string" || typeof height === "string";
-  useEffect(() => {
-    if (!needsMeasure) return;
-    if (!containerRef.current) return;
+  const pixelWidth = resolvedWidth * (terminalInfo?.cellWidth ?? 0);
+  const pixelHeight = resolvedHeight * (terminalInfo?.cellHeight ?? 0);
 
-    const { width: w, height: h } = measureElement(containerRef.current);
-    if (w > 0) setMeasuredWidth(w);
-    if (h > 0) setMeasuredHeight(h);
+  const { imageData, error } = useImage({
+    src,
+    pixelWidth,
+    pixelHeight,
+    mode: "pixels",
   });
 
-  const resolvedWidth = typeof width === "number" ? width : measuredWidth;
-  const resolvedHeight = typeof height === "number" ? height : measuredHeight;
+  const imageOutput = useMemo(() => {
+    if (!imageData) return undefined;
+    return renderSixel(imageData);
+  }, [imageData]);
 
-  /**
-   * Main effect for image processing and Sixel conversion.
-   *
-   * This effect:
-   * 1. Fetches and processes the source image
-   * 2. Calculates appropriate sizing based on terminal dimensions
-   * 3. Resizes image to fit within the component's allocated space
-   * 4. Ensures alpha channel is present (required by node-sixel)
-   * 5. Converts processed image data to Sixel format
-   * 6. Tracks actual size in terminal cells for cleanup purposes
-   */
-  useEffect(() => {
-    if (resolvedWidth === 0 || resolvedHeight === 0) return;
-    if (!terminalInfo) return;
-
-    const generateImageOutput = async () => {
-      const image = await fetchImage(src, allowPartial);
-      if (!image) {
-        setHasError(true);
-        return;
-      }
-      setHasError(false);
-
-      image.resize({
-        w: resolvedWidth * terminalInfo.cellWidth,
-        h: resolvedHeight * terminalInfo.cellHeight,
-      });
-      const resizedImage = await getRawPixels(image);
-
-      const output = renderSixel(resizedImage);
-      setImageOutput(output);
-    };
-    generateImageOutput();
-  }, [src, resolvedWidth, resolvedHeight, terminalInfo, allowPartial]);
-
-  /**
-   * Critical rendering effect for Sixel image display.
-   *
-   * This effect runs after every re-render to display the Sixel image because
-   * Ink overwrites the terminal content with each render cycle. This is a
-   * necessary workaround for the current Ink architecture.
-   *
-   * Process:
-   * 1. Validates that image and position data are available
-   * 2. Checks if the image would be visible within terminal bounds
-   * 3. Sets up process exit handlers for cleanup
-   * 4. Positions cursor to the correct location
-   * 5. Writes Sixel data directly to stdout
-   * 6. Restores cursor position
-   * 7. Returns cleanup function for previous render cleanup
-   *
-   * Cursor Management:
-   * - Moves cursor up to component position
-   * - Moves cursor right to correct column
-   * - Writes image data
-   * - Moves cursor back down to original position
-   *
-   * Cleanup Strategy:
-   * - Tracks previous render bounding box
-   * - Clears previous image by writing spaces
-   * - Handles process exit gracefully
-   *
-   * TODO: This may change when Ink implements incremental rendering
-   */
-  useLayoutEffect(() => {
-    if (!imageOutput) return;
-    if (!componentPosition) return;
-    if (
-      stdout.rows - componentPosition.appHeight + componentPosition.row < 0 ||
-      componentPosition.col > stdout.columns
-    )
-      return;
-
-    function onExit() {
-      shouldCleanupRef.current = false;
-    }
-    function onSigInt() {
-      shouldCleanupRef.current = false;
-      process.exit();
-    }
-    process.on("exit", onExit);
-    process.on("SIGINT", onSigInt);
-    process.on("SIGTERM", onSigInt);
-
-    let previousRenderBoundingBox:
-      | { row: number; col: number; width: number; height: number }
-      | undefined;
-    const renderTimeout = setTimeout(() => {
-      stdout.write("\x1b7"); // Save cursor position
-      stdout.write(
-        cursorUp(componentPosition.appHeight - componentPosition.row, {
-          appHeight: componentPosition.appHeight,
-          terminalHeight: stdout.rows,
-        }),
-      );
-      stdout.write("\r");
-      stdout.write(cursorForward(componentPosition.col));
-      stdout.write(imageOutput);
-      stdout.write("\x1b8"); // Restore cursor position
-
-      previousRenderBoundingBox = {
-        row: stdout.rows - componentPosition.appHeight + componentPosition.row,
-        col: componentPosition.col,
-        width: resolvedWidth,
-        height: resolvedHeight,
-      };
-    }, 100); // Delay to allow Ink/terminal to finish its render
-
-    return () => {
-      process.removeListener("exit", onExit);
-      process.removeListener("SIGINT", onSigInt);
-      process.removeListener("SIGTERM", onSigInt);
-
-      if (!shouldCleanupRef.current) return;
-      clearTimeout(renderTimeout);
-      // If we never rendered the image, nothing to clean up
-      if (!previousRenderBoundingBox) return;
-
-      stdout.write("\x1b7"); // Save cursor position
-      stdout.write(
-        cursorUp(componentPosition.appHeight - componentPosition.row, {
-          appHeight: componentPosition.appHeight,
-          terminalHeight: stdout.rows,
-        }),
-      );
-      for (let i = 0; i < previousRenderBoundingBox.height; i++) {
-        stdout.write("\r");
-        stdout.write(cursorForward(previousRenderBoundingBox.col));
-        if (inheritedBackgroundColor) {
-          stdout.write(
-            bgColorize(
-              " ".repeat(previousRenderBoundingBox.width),
-              inheritedBackgroundColor,
-            ),
-          );
-        } else {
-          stdout.write(" ".repeat(previousRenderBoundingBox.width));
-        }
-        stdout.write("\n");
-      }
-      stdout.write("\x1b8"); // Restore cursor position
-    };
-    // }, [imageOutput, ...Object.values(componentPosition)]);
+  useDirectRenderer({
+    enabled: !!imageOutput && !!componentPosition,
+    imageOutput: imageOutput ?? "",
+    position: componentPosition,
+    stdout,
+    width: resolvedWidth,
+    height: resolvedHeight,
+    backgroundColor: inheritedBackgroundColor,
   });
 
   return (
@@ -244,7 +62,7 @@ function SixelImage(props: ImageProps) {
         <Box flexDirection="column" alignItems="center" justifyContent="center">
           {alt ? (
             <Text color="gray">{alt}</Text>
-          ) : hasError ? (
+          ) : error ? (
             <Text color="red">
               X<Newline />
               Load failed

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -1,4 +1,4 @@
-import { Box, Newline, Text, useStdout } from "ink";
+import { useStdout } from "ink";
 import React, { useMemo } from "react";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import useBackgroundColor from "../../hooks/useBackgroundColor.js";
@@ -7,12 +7,13 @@ import { useImage } from "../../hooks/useImage.js";
 import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import usePosition from "../../hooks/usePosition.js";
 import { renderSixel } from "../../renderers/sixel.js";
+import ImageBox from "../ImageBox.js";
 import type { ImageProps } from "./protocol.js";
 
 function SixelImage(props: ImageProps) {
   const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const { src, width, height, alt, allowPartial } = props;
+  const { src, width, height, alt } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -48,31 +49,14 @@ function SixelImage(props: ImageProps) {
   });
 
   return (
-    <Box
+    <ImageBox
       ref={containerRef}
-      flexDirection="column"
       width={width}
       height={height}
-    >
-      {imageOutput ? (
-        <Text color="gray" wrap="wrap">
-          {alt ?? "Loading..."}
-        </Text>
-      ) : (
-        <Box flexDirection="column" alignItems="center" justifyContent="center">
-          {alt ? (
-            <Text color="gray">{alt}</Text>
-          ) : error ? (
-            <Text color="red">
-              X<Newline />
-              Load failed
-            </Text>
-          ) : (
-            <Text color="gray">Loading...</Text>
-          )}
-        </Box>
-      )}
-    </Box>
+      alt={alt}
+      error={error}
+      loaded={!!imageOutput}
+    />
   );
 }
 

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -7,17 +7,16 @@ import {
   useStdout,
 } from "ink";
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { image2sixel } from "sixel";
 import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import useBackgroundColor from "../../hooks/useBackgroundColor.js";
 import usePosition from "../../hooks/usePosition.js";
+import { renderSixel } from "../../renderers/sixel.js";
 import { cursorForward, cursorUp } from "../../utils/ansiEscapes.js";
 import bgColorize from "../../utils/bgColorize.js";
 import {
   calculateImageSize,
   fetchImage,
   getRawPixels,
-  type ImageOutputInfo,
 } from "../../utils/image.js";
 import type { ImageProps } from "./protocol.js";
 
@@ -114,7 +113,7 @@ function SixelImage(props: ImageProps) {
       });
       const resizedImage = await getRawPixels(image);
 
-      const output = await toSixel(resizedImage);
+      const output = renderSixel(resizedImage);
       setImageOutput(output);
     };
     generateImageOutput();
@@ -257,26 +256,6 @@ function SixelImage(props: ImageProps) {
       )}
     </Box>
   );
-}
-
-/**
- * Converts processed image data to Sixel format.
- *
- * This function takes raw RGBA image data from Jimp and converts it to
- * the Sixel graphics format using the node-sixel library. The resulting
- * string contains escape sequences that can be written directly to a
- * terminal that supports Sixel graphics.
- *
- * @param imageData - Raw image data with buffer and metadata from Jimp
- * @returns Promise resolving to Sixel-formatted string
- */
-async function toSixel(imageData: { data: Buffer; info: ImageOutputInfo }) {
-  const { data, info } = imageData;
-  const { width, height } = info;
-  const u8Data = new Uint8Array(data);
-
-  const sixelData = image2sixel(u8Data, width, height);
-  return sixelData;
 }
 
 export default SixelImage;

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -4,7 +4,7 @@ import { useTerminalInfo } from "../../context/TerminalInfo.js";
 import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import usePosition from "../../hooks/usePosition.js";
 import useProtocol from "../../hooks/useProtocol.js";
-import type { GetVisibility } from "../../hooks/useVisibility.js";
+import type { GetVisibility, Visibility } from "../../hooks/useVisibility.js";
 import { useVisibility } from "../../hooks/useVisibility.js";
 import AsciiImage from "./Ascii.js";
 import BrailleImage from "./Braille.js";
@@ -25,6 +25,8 @@ const imageProtocols = {
 
 export type ImageProtocolName = keyof typeof imageProtocols;
 
+export type ImageProtocolHint = Partial<Record<Visibility, ImageProtocolName>>;
+
 const ImageRenderer = (props: ImageProps & { protocol: ImageProtocolName }) => {
   const ProtocolComponent = imageProtocols[props.protocol];
   return <ProtocolComponent {...props} />;
@@ -33,7 +35,7 @@ const ImageRenderer = (props: ImageProps & { protocol: ImageProtocolName }) => {
 type ImageComponentProps = Omit<ImageProps, "width" | "height"> & {
   width?: number | string;
   height?: number | string;
-  protocol?: ImageProtocolName;
+  protocol?: ImageProtocolName | ImageProtocolHint;
   getVisibility?: GetVisibility;
 };
 
@@ -47,7 +49,9 @@ function Image({
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
   const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const protocol = useProtocol(specifiedProtocol);
+  const protocol = useProtocol(
+    typeof specifiedProtocol === "string" ? specifiedProtocol : undefined,
+  );
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -63,14 +67,21 @@ function Image({
   );
 
   const effectiveProtocol = useMemo((): ImageProtocolName => {
-    if (specifiedProtocol) return specifiedProtocol;
+    if (typeof specifiedProtocol === "string") return specifiedProtocol;
+
+    const hints: ImageProtocolHint = specifiedProtocol ?? {};
+    const hint = hints[visibility];
+    if (hint) return hint;
+
     if (visibility === "full") return protocol;
+
     if (
       protocol === "ascii" ||
       protocol === "braille" ||
       protocol === "halfBlock"
     )
       return protocol;
+
     if (terminalInfo.supportsUnicode && terminalInfo.supportsColor)
       return "halfBlock";
     if (terminalInfo.supportsUnicode) return "braille";

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -1,7 +1,11 @@
-import { Box, Text, useIsScreenReaderEnabled } from "ink";
-import React, { useCallback, useState } from "react";
+import { Box, useIsScreenReaderEnabled, useStdout } from "ink";
+import React, { useMemo } from "react";
+import { useTerminalInfo } from "../../context/TerminalInfo.js";
+import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
+import usePosition from "../../hooks/usePosition.js";
 import useProtocol from "../../hooks/useProtocol.js";
-import { getBestProtocol } from "../../utils/getBestProtocol.js";
+import type { GetVisibility } from "../../hooks/useVisibility.js";
+import { useVisibility } from "../../hooks/useVisibility.js";
 import AsciiImage from "./Ascii.js";
 import BrailleImage from "./Braille.js";
 import HalfBlockImage from "./HalfBlock.js";
@@ -21,90 +25,71 @@ const imageProtocols = {
 
 export type ImageProtocolName = keyof typeof imageProtocols;
 
-/**
- * Internal component that renders an image using a specific protocol.
- *
- * @param props - Image props with protocol specification
- * @returns JSX element rendering the image with the specified protocol
- */
 const ImageRenderer = (props: ImageProps & { protocol: ImageProtocolName }) => {
   const ProtocolComponent = imageProtocols[props.protocol];
   return <ProtocolComponent {...props} />;
 };
 
-/**
- * Main Image component with automatic protocol fallback.
- *
- * This component automatically detects terminal capabilities and falls back
- * to supported rendering protocols in order of preference:
- * halfBlock -> braille -> ascii
- *
- * **IMPORTANT: TerminalInfo Provider Requirement**
- * This component MUST be used within a `<TerminalInfoProvider>` component tree.
- * The Image component requires terminal capability detection to function properly
- * and will throw an error if the TerminalInfo context is not available.
- *
- * Example usage:
- * ```tsx
- * import React from 'react';
- * import { Box } from 'ink';
- * import { TerminalInfoProvider } from '../context/TerminalInfo.js';
- * import Image from './components/image/index.js';
- *
- * function App() {
- *   return (
- *     <TerminalInfoProvider>
- *       <Box flexDirection="column">
- *         <Image
- *           src="https://example.com/image.jpg"
- *           width={40}
- *           height={20}
- *           alt="Example image"
- *         />
- *         <Image
- *           src="/local/path/image.png"
- *           protocol="sixel"
- *         />
- *       </Box>
- *     </TerminalInfoProvider>
- *   );
- * }
- * ```
- *
- * Features:
- * - Automatic protocol detection and fallback
- * - Support for multiple image formats (PNG, JPEG, WebP, etc.)
- * - Responsive sizing based on parent container dimensions
- * - Error handling with graceful degradation
- * - Terminal capability detection for optimal rendering
- * - Support for both local files and remote URLs
- *
- * Protocol Options:
- * - `sixel`: (experimental) Highest quality, requires Sixel graphics support
- * - `kitty`: (experimental) High quality, requires Kitty graphics support
- * - `iterm2`: (experimental) High quality, requires iTerm2 graphics support
- * - `braille`: High resolution monochrome, requires Unicode support
- * - `halfBlock`: Good color quality, requires Unicode and color support
- * - `ascii`: Universal compatibility, works in all terminals
- *
- * @param props - Image properties including source, dimensions, and initial protocol
- * @returns JSX element rendering the image with the best supported protocol
- * @throws Error if not used within TerminalInfoProvider context
- */
+type ImageComponentProps = Omit<ImageProps, "width" | "height"> & {
+  width?: number | string;
+  height?: number | string;
+  protocol?: ImageProtocolName;
+  getVisibility?: GetVisibility;
+};
+
 function Image({
   protocol: specifiedProtocol,
+  getVisibility,
+  width = "100%",
+  height = "100%",
   ...props
-}: Omit<ImageProps & { protocol?: ImageProtocolName }, "onSupportDetected">) {
+}: ImageComponentProps) {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
+  const terminalInfo = useTerminalInfo();
+  const { stdout } = useStdout();
   const protocol = useProtocol(specifiedProtocol);
 
+  const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
+    width,
+    height,
+  );
+
+  const position = usePosition(containerRef);
+  const visibility = useVisibility(
+    position,
+    stdout.rows,
+    stdout.columns,
+    getVisibility,
+  );
+
+  const effectiveProtocol = useMemo((): ImageProtocolName => {
+    if (specifiedProtocol) return specifiedProtocol;
+    if (visibility === "full") return protocol;
+    if (
+      protocol === "ascii" ||
+      protocol === "braille" ||
+      protocol === "halfBlock"
+    )
+      return protocol;
+    if (terminalInfo.supportsUnicode && terminalInfo.supportsColor)
+      return "halfBlock";
+    if (terminalInfo.supportsUnicode) return "braille";
+    return "ascii";
+  }, [
+    visibility,
+    protocol,
+    specifiedProtocol,
+    terminalInfo.supportsUnicode,
+    terminalInfo.supportsColor,
+  ]);
+
   if (isScreenReaderEnabled) {
-    const { src, alt, width, height } = props;
-    // Simulate aria-role because Ink doesn't have a image role
+    const { src, alt } = props;
     const label = `image: ${alt || (typeof src === "string" ? src : "binary image data")}`;
 
     return (
       <Box
+        ref={containerRef}
         width={width}
         height={height}
         aria-label={label}
@@ -113,7 +98,22 @@ function Image({
     );
   }
 
-  return <ImageRenderer protocol={protocol} key={protocol} {...props} />;
+  return (
+    <Box
+      ref={containerRef}
+      width={width}
+      height={height}
+      flexDirection="column"
+    >
+      <ImageRenderer
+        protocol={effectiveProtocol}
+        key={effectiveProtocol}
+        width={resolvedWidth}
+        height={resolvedHeight}
+        {...props}
+      />
+    </Box>
+  );
 }
 
 export default Image;

--- a/src/components/image/protocol.ts
+++ b/src/components/image/protocol.ts
@@ -20,8 +20,6 @@ export interface ImageProps {
   height: number | string;
   /** Alternative text displayed while loading or on error */
   alt?: string;
-  /** Supports partially loaded image reading */
-  allowPartial?: boolean;
 }
 
 /**

--- a/src/hooks/useDirectRenderer.ts
+++ b/src/hooks/useDirectRenderer.ts
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef } from "react";
 import { cursorForward, cursorUp } from "../utils/ansiEscapes.js";
 import bgColorize from "../utils/bgColorize.js";
 import type { Position } from "./usePosition.js";
+import { defaultVisibility } from "./useVisibility.js";
 
 interface DirectRendererOptions {
   enabled: boolean;
@@ -34,10 +35,7 @@ export function useDirectRenderer(options: DirectRendererOptions) {
   useLayoutEffect(() => {
     if (!enabled) return;
     if (!position) return;
-    if (
-      stdout.rows - position.appHeight + position.row < 0 ||
-      position.col > stdout.columns
-    )
+    if (defaultVisibility(position, stdout.rows, stdout.columns) !== "full")
       return;
 
     shouldCleanupRef.current = true;

--- a/src/hooks/useDirectRenderer.ts
+++ b/src/hooks/useDirectRenderer.ts
@@ -1,0 +1,108 @@
+import { useLayoutEffect, useRef } from "react";
+import { cursorForward, cursorUp } from "../utils/ansiEscapes.js";
+import bgColorize from "../utils/bgColorize.js";
+import type { Position } from "./usePosition.js";
+
+interface DirectRendererOptions {
+  enabled: boolean;
+  imageOutput: string;
+  position: Position | undefined;
+  stdout: NodeJS.WriteStream;
+  width: number;
+  height: number;
+  backgroundColor?: string;
+}
+
+export function useDirectRenderer(options: DirectRendererOptions) {
+  const {
+    enabled,
+    imageOutput,
+    position,
+    stdout,
+    width,
+    height,
+    backgroundColor,
+  } = options;
+  const shouldCleanupRef = useRef(true);
+  const previousBboxRef = useRef<
+    { row: number; col: number; width: number; height: number } | undefined
+  >(undefined);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    if (!position) return;
+    if (
+      stdout.rows - position.appHeight + position.row < 0 ||
+      position.col > stdout.columns
+    )
+      return;
+
+    shouldCleanupRef.current = true;
+
+    function onExit() {
+      shouldCleanupRef.current = false;
+    }
+    function onSigInt() {
+      shouldCleanupRef.current = false;
+      process.exit();
+    }
+    process.on("exit", onExit);
+    process.on("SIGINT", onSigInt);
+    process.on("SIGTERM", onSigInt);
+
+    timeoutRef.current = setTimeout(() => {
+      stdout.write("\x1b7"); // Save cursor position
+      stdout.write(
+        cursorUp(position.appHeight - position.row, {
+          appHeight: position.appHeight,
+          terminalHeight: stdout.rows,
+        }),
+      );
+      stdout.write("\r");
+      stdout.write(cursorForward(position.col));
+      stdout.write(imageOutput);
+      stdout.write("\x1b8"); // Restore cursor position
+
+      previousBboxRef.current = {
+        row: stdout.rows - position.appHeight + position.row,
+        col: position.col,
+        width,
+        height,
+      };
+    }, 100);
+
+    return () => {
+      process.removeListener("exit", onExit);
+      process.removeListener("SIGINT", onSigInt);
+      process.removeListener("SIGTERM", onSigInt);
+
+      if (!shouldCleanupRef.current) return;
+      clearTimeout(timeoutRef.current);
+
+      const bbox = previousBboxRef.current;
+      if (!bbox) return;
+
+      stdout.write("\x1b7");
+      stdout.write(
+        cursorUp(position.appHeight - position.row, {
+          appHeight: position.appHeight,
+          terminalHeight: stdout.rows,
+        }),
+      );
+      for (let i = 0; i < bbox.height; i++) {
+        stdout.write("\r");
+        stdout.write(cursorForward(bbox.col));
+        if (backgroundColor) {
+          stdout.write(bgColorize(" ".repeat(bbox.width), backgroundColor));
+        } else {
+          stdout.write(" ".repeat(bbox.width));
+        }
+        stdout.write("\n");
+      }
+      stdout.write("\x1b8");
+    };
+  });
+}

--- a/src/hooks/useImage.ts
+++ b/src/hooks/useImage.ts
@@ -1,0 +1,61 @@
+import { type Jimp } from "jimp";
+import { useEffect, useState } from "react";
+import type { PixelData, PngData } from "../renderers/types.js";
+import { fetchImage, getPngBuffer, getRawPixels } from "../utils/image.js";
+
+export function useImage<T extends "pixels" | "png" = "pixels">(options: {
+  src: Parameters<typeof Jimp.read>[0];
+  pixelWidth: number;
+  pixelHeight: number;
+  mode?: T;
+}): T extends "png"
+  ? { imageData: PngData | undefined; error: boolean }
+  : { imageData: PixelData | undefined; error: boolean } {
+  const { src, pixelWidth, pixelHeight, mode = "pixels" } = options;
+  const [imageData, setImageData] = useState<PngData | PixelData | undefined>(
+    undefined,
+  );
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (pixelWidth === 0 || pixelHeight === 0) return;
+
+    let cancelled = false;
+
+    const load = async () => {
+      const image = await fetchImage(src);
+      if (cancelled) return;
+
+      if (!image) {
+        setError(true);
+        setImageData(undefined);
+        return;
+      }
+
+      setError(false);
+      image.resize({ w: pixelWidth, h: pixelHeight });
+
+      if (mode === "png") {
+        const result = await getPngBuffer(image);
+        if (!cancelled) {
+          setImageData(result);
+        }
+      } else {
+        const result = await getRawPixels(image);
+        if (!cancelled) {
+          setImageData(result);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [src, pixelWidth, pixelHeight, mode]);
+
+  return { imageData, error } as T extends "png"
+    ? { imageData: PngData | undefined; error: boolean }
+    : { imageData: PixelData | undefined; error: boolean };
+}

--- a/src/hooks/useImage.ts
+++ b/src/hooks/useImage.ts
@@ -2,6 +2,7 @@ import { type Jimp } from "jimp";
 import { useEffect, useState } from "react";
 import type { PixelData, PngData } from "../renderers/types.js";
 import { fetchImage, getPngBuffer, getRawPixels } from "../utils/image.js";
+import { getCachedImage, setCachedImage } from "../utils/imageCache.js";
 
 export function useImage<T extends "pixels" | "png" = "pixels">(options: {
   src: Parameters<typeof Jimp.read>[0];
@@ -23,13 +24,21 @@ export function useImage<T extends "pixels" | "png" = "pixels">(options: {
     let cancelled = false;
 
     const load = async () => {
-      const image = await fetchImage(src);
-      if (cancelled) return;
+      let image = typeof src === "string" ? getCachedImage(src) : undefined;
 
       if (!image) {
-        setError(true);
-        setImageData(undefined);
-        return;
+        image = await fetchImage(src);
+        if (cancelled) return;
+
+        if (!image) {
+          setError(true);
+          setImageData(undefined);
+          return;
+        }
+
+        if (typeof src === "string") {
+          setCachedImage(src, image);
+        }
       }
 
       setError(false);

--- a/src/hooks/useMeasuredSize.ts
+++ b/src/hooks/useMeasuredSize.ts
@@ -1,0 +1,27 @@
+import { type DOMElement, measureElement } from "ink";
+import { useEffect, useRef, useState } from "react";
+
+export function useMeasuredSize(
+  width: number | string,
+  height: number | string,
+) {
+  const containerRef = useRef<DOMElement | null>(null);
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const [measuredHeight, setMeasuredHeight] = useState(0);
+
+  const needsMeasure = typeof width === "string" || typeof height === "string";
+  useEffect(() => {
+    if (!needsMeasure) return;
+    if (!containerRef.current) return;
+
+    const { width: w, height: h } = measureElement(containerRef.current);
+    if (w > 0) setMeasuredWidth(w);
+    if (h > 0) setMeasuredHeight(h);
+  });
+
+  return {
+    containerRef,
+    resolvedWidth: typeof width === "number" ? width : measuredWidth,
+    resolvedHeight: typeof height === "number" ? height : measuredHeight,
+  };
+}

--- a/src/hooks/usePosition.ts
+++ b/src/hooks/usePosition.ts
@@ -40,11 +40,11 @@ const usePosition = (
   const [position, setPosition] = useState<Position | undefined>(undefined);
 
   const updatePosition = useCallback(() => {
-    if (!ref.current?.yogaNode) {
+    const node = ref.current;
+    if (!node?.yogaNode) {
       return;
     }
 
-    const { current: node } = ref;
     const { yogaNode } = node;
 
     // Calculate absolute position by traversing up the tree
@@ -68,8 +68,8 @@ const usePosition = (
     const newPosition: Position = {
       col: absoluteCol,
       row: absoluteRow,
-      width: yogaNode!.getComputedWidth(),
-      height: yogaNode!.getComputedHeight(),
+      width: yogaNode.getComputedWidth(),
+      height: yogaNode.getComputedHeight(),
       appWidth,
       appHeight,
     };
@@ -93,11 +93,21 @@ const usePosition = (
   }, [ref]);
 
   // Calculate position after every render
-  // This ensures we capture all layout changes from the root node down
-  // Otherwise we will need to track changes in all of the node's parent nodes which is also expensive
+  // This captures layout changes caused by the component's own re-renders
   useEffect(() => {
     updatePosition();
   });
+
+  // Poll to detect layout changes that happen without re-rendering
+  // e.g. parent layout changes, where React bails out from re-rendering children
+  useEffect(() => {
+    const interval = setInterval(updatePosition, 16);
+    interval.unref();
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [updatePosition]);
 
   return position;
 };

--- a/src/hooks/useProtocol.ts
+++ b/src/hooks/useProtocol.ts
@@ -1,5 +1,5 @@
-import { useTerminalInfo } from "../context/TerminalInfo";
-import { getBestProtocol } from "../utils/getBestProtocol";
+import { useTerminalInfo } from "../context/TerminalInfo.js";
+import { getBestProtocol } from "../utils/getBestProtocol.js";
 
 export default function useProtocol(
   specifiedProtocol?:

--- a/src/hooks/useVisibility.ts
+++ b/src/hooks/useVisibility.ts
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import type { Position } from "./usePosition.js";
+
+export type Visibility = "full" | "partial" | "hidden";
+
+export interface VisibilityInfo {
+  position: Position;
+  terminalWidth: number;
+  terminalHeight: number;
+  defaultVisibility: Visibility;
+}
+
+export type GetVisibility = (info: VisibilityInfo) => Visibility;
+
+export function defaultVisibility(
+  position: Position,
+  terminalHeight: number,
+  terminalWidth: number,
+): Visibility {
+  const viewportStartRow = terminalHeight - position.appHeight + position.row;
+  const viewportEndRow = viewportStartRow + position.height;
+  const inAppStartRow = position.row;
+  const inAppEndRow = inAppStartRow + position.height;
+
+  if (
+    viewportEndRow <= 0 ||
+    inAppEndRow <= 0 ||
+    viewportStartRow >= terminalHeight ||
+    inAppStartRow >= position.appHeight
+  ) {
+    return "hidden";
+  }
+
+  const viewportEndCol = position.col + position.width;
+  if (
+    viewportEndCol <= 0 ||
+    position.col >= terminalWidth ||
+    position.col >= position.appWidth
+  ) {
+    return "hidden";
+  }
+
+  if (
+    viewportStartRow < 0 ||
+    inAppStartRow < 0 ||
+    viewportEndRow > terminalHeight ||
+    inAppEndRow > position.appHeight ||
+    position.col < 0 ||
+    viewportEndCol > terminalWidth ||
+    viewportEndCol > position.appWidth
+  ) {
+    return "partial";
+  }
+
+  return "full";
+}
+
+export function useVisibility(
+  position: Position | undefined,
+  terminalHeight: number,
+  terminalWidth: number,
+  getVisibility?: GetVisibility,
+): Visibility {
+  return useMemo(() => {
+    if (!position) return "hidden";
+
+    const visibility = defaultVisibility(
+      position,
+      terminalHeight,
+      terminalWidth,
+    );
+
+    if (getVisibility) {
+      return getVisibility({
+        position,
+        terminalWidth,
+        terminalHeight,
+        defaultVisibility: visibility,
+      });
+    }
+
+    return visibility;
+  }, [position, terminalHeight, terminalWidth, getVisibility]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,4 +59,9 @@ export type {
 } from "./hooks/useVisibility.js";
 export { useVisibility } from "./hooks/useVisibility.js";
 
-// Note: utils are kept internal for now, but can be exported later if needed
+export {
+  clearImageCache,
+  getCachedImage,
+  getCacheSize,
+  setCachedImage,
+} from "./utils/imageCache.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,10 @@
 export { default as AsciiImage } from "./components/image/Ascii.js";
 export { default as BrailleImage } from "./components/image/Braille.js";
 export { default as HalfBlockImage } from "./components/image/HalfBlock.js";
-export type { ImageProtocolName } from "./components/image/index.js";
+export type {
+  ImageProtocolHint,
+  ImageProtocolName,
+} from "./components/image/index.js";
 // Main Image component - the primary export
 export { default } from "./components/image/index.js";
 // Types and interfaces

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,5 +52,11 @@ export {
 
 // Utility hooks
 export { default as usePosition } from "./hooks/usePosition.js";
+export type {
+  GetVisibility,
+  Visibility,
+  VisibilityInfo,
+} from "./hooks/useVisibility.js";
+export { useVisibility } from "./hooks/useVisibility.js";
 
 // Note: utils are kept internal for now, but can be exported later if needed

--- a/src/renderers/ascii.ts
+++ b/src/renderers/ascii.ts
@@ -1,0 +1,41 @@
+import chalk from "chalk";
+import type { PixelData } from "./types.js";
+
+const ASCII_CHARS =
+  "$@B%8&WM#*oahkbdpqwmZO0QLCJUYXzcvunxrjft/\\|()1{}[]?-_+~<>i!lI;:,\"^`'. ";
+
+export function renderAscii(
+  pixels: PixelData,
+  options: { colored?: boolean } = {},
+): string {
+  const { data, info } = pixels;
+  const { width, height, channels } = info;
+  const colored = options.colored ?? true;
+
+  let result = "";
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const pixelIndex = (y * width + x) * channels;
+
+      const r = data[pixelIndex] as number;
+      const g = data[pixelIndex + 1] as number;
+      const b = data[pixelIndex + 2] as number;
+      const a = channels === 4 ? (data[pixelIndex + 3] as number) : 255;
+
+      const sum = r + g + b + a;
+      const intensity = sum === 0 ? 0 : sum / (255 * 4);
+      const char =
+        ASCII_CHARS[
+          ASCII_CHARS.length -
+            1 -
+            Math.floor(intensity * (ASCII_CHARS.length - 1))
+        ];
+
+      result += colored ? chalk.rgb(r, g, b)(char) : char;
+    }
+
+    result += "\n";
+  }
+
+  return result.slice(0, -1);
+}

--- a/src/renderers/braille.ts
+++ b/src/renderers/braille.ts
@@ -1,0 +1,74 @@
+import type { PixelData } from "./types.js";
+
+export function renderBraille(pixels: PixelData): string {
+  const { data, info } = pixels;
+  const { width, height, channels } = info;
+
+  let result = "";
+  for (let y = 0; y < height - 3; y += 4) {
+    for (let x = 0; x < width - 1; x += 2) {
+      const dot1Index = (y * width + x) * channels;
+      const dot2Index = ((y + 1) * width + x) * channels;
+      const dot3Index = ((y + 2) * width + x) * channels;
+      const dot4Index = (y * width + x + 1) * channels;
+      const dot5Index = ((y + 1) * width + x + 1) * channels;
+      const dot6Index = ((y + 2) * width + x + 1) * channels;
+      const dot7Index = ((y + 3) * width + x) * channels;
+      const dot8Index = ((y + 3) * width + x + 1) * channels;
+
+      const getRgba = (index: number) => {
+        const r = data[index] as number;
+        const g = data[index + 1] as number;
+        const b = data[index + 2] as number;
+        const a = channels === 4 ? (data[index + 3] as number) : 1;
+        return { r, g, b, a };
+      };
+
+      const dot1 = rgbaToBlackOrWhite(getRgba(dot1Index));
+      const dot2 = rgbaToBlackOrWhite(getRgba(dot2Index));
+      const dot3 = rgbaToBlackOrWhite(getRgba(dot3Index));
+      const dot4 = rgbaToBlackOrWhite(getRgba(dot4Index));
+      const dot5 = rgbaToBlackOrWhite(getRgba(dot5Index));
+      const dot6 = rgbaToBlackOrWhite(getRgba(dot6Index));
+      const dot7 = rgbaToBlackOrWhite(getRgba(dot7Index));
+      const dot8 = rgbaToBlackOrWhite(getRgba(dot8Index));
+
+      const brailleChar = String.fromCharCode(
+        0x2800 +
+          (dot8 << 7) +
+          (dot7 << 6) +
+          (dot6 << 5) +
+          (dot5 << 4) +
+          (dot4 << 3) +
+          (dot3 << 2) +
+          (dot2 << 1) +
+          dot1,
+      );
+      result += brailleChar;
+    }
+    result += "\n";
+  }
+
+  return result.slice(0, -1);
+}
+
+function rgbaToBlackOrWhite({
+  r,
+  g,
+  b,
+  a,
+}: {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}) {
+  const alpha = a / 255;
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  const alphaAdjustedLuminance = luminance * alpha + 255 * (1 - alpha);
+
+  if (alphaAdjustedLuminance > 128) {
+    return 1;
+  }
+  return 0;
+}

--- a/src/renderers/halfBlock.ts
+++ b/src/renderers/halfBlock.ts
@@ -1,0 +1,35 @@
+import chalk from "chalk";
+import type { PixelData } from "./types.js";
+
+const HALF_BLOCK = "\u2584";
+
+export function renderHalfBlock(pixels: PixelData): string {
+  const { data, info } = pixels;
+  const { width, height, channels } = info;
+
+  let result = "";
+  for (let y = 0; y < height - 1; y += 2) {
+    for (let x = 0; x < width; x++) {
+      const topPixelIndex = (y * width + x) * channels;
+      const bottomPixelIndex = ((y + 1) * width + x) * channels;
+
+      const r = data[topPixelIndex] as number;
+      const g = data[topPixelIndex + 1] as number;
+      const b = data[topPixelIndex + 2] as number;
+      const a = channels === 4 ? (data[topPixelIndex + 3] as number) : 255;
+
+      const r2 = data[bottomPixelIndex] as number;
+      const g2 = data[bottomPixelIndex + 1] as number;
+      const b2 = data[bottomPixelIndex + 2] as number;
+
+      result +=
+        a === 0
+          ? chalk.reset(" ")
+          : chalk.bgRgb(r, g, b).rgb(r2, g2, b2)(HALF_BLOCK);
+    }
+
+    result += "\n";
+  }
+
+  return result.slice(0, -1);
+}

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -1,0 +1,11 @@
+export { renderAscii } from "./ascii.js";
+export { renderBraille } from "./braille.js";
+export { renderHalfBlock } from "./halfBlock.js";
+export { renderITerm2 } from "./iterm2.js";
+export {
+  makeKittyDeletion,
+  makeKittyPlacement,
+  makeKittyTransmitChunks,
+} from "./kitty.js";
+export { renderSixel } from "./sixel.js";
+export type { PixelData, PngData } from "./types.js";

--- a/src/renderers/iterm2.ts
+++ b/src/renderers/iterm2.ts
@@ -1,0 +1,19 @@
+import type { PngData } from "./types.js";
+
+export function renderITerm2(
+  png: PngData,
+  options: { width: number; height: number },
+): string {
+  const { data } = png;
+  const { width, height } = options;
+
+  return (
+    "\x1b]1337;File=" +
+    `size=${data.length};` +
+    `width=${width}px;height=${height}px;` +
+    `preserveAspectRatio=1;` +
+    `inline=1:` +
+    data.toString("base64") +
+    "\x07"
+  );
+}

--- a/src/renderers/kitty.ts
+++ b/src/renderers/kitty.ts
@@ -35,6 +35,12 @@ export function makeKittyPlacement(
   return `\x1b_Ga=p,i=${imageId},p=${placementId},C=1,q=2\x1b\\`;
 }
 
-export function makeKittyDeletion(imageId: number): string {
+export function makeKittyDeletion(
+  imageId: number,
+  placementId?: number,
+): string {
+  if (placementId !== undefined) {
+    return `\x1b_Ga=d,d=i,p=${placementId},i=${imageId}\x1b\\`;
+  }
   return `\x1b_Ga=d,d=I,i=${imageId}\x1b\\`;
 }

--- a/src/renderers/kitty.ts
+++ b/src/renderers/kitty.ts
@@ -1,0 +1,40 @@
+const DEFAULT_CHUNK_SIZE = 4096;
+
+export function makeKittyTransmitChunks(
+  imageId: number,
+  pngBase64: string,
+  chunkSize: number = DEFAULT_CHUNK_SIZE,
+): string[] {
+  const chunks: string[] = [];
+
+  if (pngBase64.length <= chunkSize) {
+    chunks.push(`\x1b_Gf=100,t=d,i=${imageId},m=0,q=2;${pngBase64}\x1b\\`);
+    return chunks;
+  }
+
+  const firstChunk = pngBase64.slice(0, chunkSize);
+  chunks.push(`\x1b_Gf=100,t=d,i=${imageId},m=1,q=2;${firstChunk}\x1b\\`);
+
+  let bufferOffset = chunkSize;
+  while (bufferOffset < pngBase64.length - chunkSize) {
+    const chunk = pngBase64.slice(bufferOffset, bufferOffset + chunkSize);
+    bufferOffset += chunkSize;
+    chunks.push(`\x1b_Gm=1,q=2;${chunk}\x1b\\`);
+  }
+
+  const lastChunk = pngBase64.slice(bufferOffset);
+  chunks.push(`\x1b_Gm=0,q=2;${lastChunk}\x1b\\`);
+
+  return chunks;
+}
+
+export function makeKittyPlacement(
+  imageId: number,
+  placementId: number = 1,
+): string {
+  return `\x1b_Ga=p,i=${imageId},p=${placementId},C=1,q=2\x1b\\`;
+}
+
+export function makeKittyDeletion(imageId: number): string {
+  return `\x1b_Ga=d,d=I,i=${imageId}\x1b\\`;
+}

--- a/src/renderers/sixel.ts
+++ b/src/renderers/sixel.ts
@@ -1,0 +1,8 @@
+import { image2sixel } from "sixel";
+import type { PixelData } from "./types.js";
+
+export function renderSixel(pixels: PixelData): string {
+  const { data, info } = pixels;
+  const u8Data = new Uint8Array(data);
+  return image2sixel(u8Data, info.width, info.height);
+}

--- a/src/renderers/types.ts
+++ b/src/renderers/types.ts
@@ -1,0 +1,16 @@
+export interface PixelData {
+  data: Buffer;
+  info: {
+    width: number;
+    height: number;
+    channels: number;
+  };
+}
+
+export interface PngData {
+  data: Buffer;
+  info: {
+    width: number;
+    height: number;
+  };
+}

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -13,8 +13,6 @@ export interface ImageOutputInfo {
 
 export async function fetchImage(
   src: Parameters<typeof Jimp.read>[0],
-  // jimp doesn't support partial image loading, kept for backwards compatibility
-  _allowPartial = false,
 ): Promise<JimpImage | undefined> {
   try {
     if (typeof src === "string" && src.startsWith("file://")) {

--- a/src/utils/imageCache.ts
+++ b/src/utils/imageCache.ts
@@ -1,0 +1,68 @@
+import type { JimpImage } from "./image.js";
+
+const ENV_MAX_ENTRIES = "INK_PICTURE_CACHE_SIZE";
+
+class ImageCache {
+  #cache = new Map<string, JimpImage>();
+  #maxEntries: number;
+
+  constructor(maxEntries: number) {
+    this.#maxEntries = Math.max(1, maxEntries);
+  }
+
+  get(key: string): JimpImage | undefined {
+    const entry = this.#cache.get(key);
+    if (!entry) return undefined;
+
+    this.#cache.delete(key);
+    this.#cache.set(key, entry);
+
+    return entry.clone();
+  }
+
+  set(key: string, image: JimpImage): void {
+    this.#cache.delete(key);
+
+    while (this.#cache.size >= this.#maxEntries) {
+      const lru = this.#cache.keys().next().value;
+      if (lru !== undefined) this.#cache.delete(lru);
+    }
+
+    this.#cache.set(key, image.clone());
+  }
+
+  clear(): void {
+    this.#cache.clear();
+  }
+
+  get size(): number {
+    return this.#cache.size;
+  }
+}
+
+function parseCacheSize(): number {
+  const raw = process.env[ENV_MAX_ENTRIES];
+  if (raw === undefined) return 10;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return 10;
+  return n;
+}
+
+const maxEntries = parseCacheSize();
+const cache = maxEntries === 0 ? null : new ImageCache(maxEntries);
+
+export function getCachedImage(src: string): JimpImage | undefined {
+  return cache?.get(src);
+}
+
+export function setCachedImage(src: string, image: JimpImage): void {
+  cache?.set(src, image);
+}
+
+export function clearImageCache(): void {
+  cache?.clear();
+}
+
+export function getCacheSize(): number {
+  return cache?.size ?? 0;
+}

--- a/tests/playwright/fixtures/auto-image.tsx
+++ b/tests/playwright/fixtures/auto-image.tsx
@@ -1,0 +1,55 @@
+import process from "node:process";
+import { Box, render } from "ink";
+import React from "react";
+import Image, { TerminalInfoProvider } from "../../../src";
+
+function parseArgs(args: string[]) {
+  const result: Record<string, boolean | string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+
+      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        result[key] = args[++i];
+      } else {
+        result[key] = true;
+      }
+    }
+  }
+
+  return result;
+}
+
+const parsed = parseArgs(process.argv.slice(2));
+const imagePath = (parsed.src as string) || "";
+const imageWidth = parsed.width
+  ? parseInt(parsed.width as string, 10)
+  : undefined;
+const imageHeight = parsed.height
+  ? parseInt(parsed.height as string, 10)
+  : undefined;
+const keepalive = parsed.keepalive === true;
+
+export function App() {
+  if (keepalive) {
+    setInterval(() => {}, 10000);
+  }
+
+  return (
+    <TerminalInfoProvider>
+      <Box flexDirection="row" width={80} height={24}>
+        <Image
+          src={imagePath}
+          width={imageWidth}
+          height={imageHeight}
+          alt="Auto-detect test"
+        />
+      </Box>
+    </TerminalInfoProvider>
+  );
+}
+
+render(<App />);

--- a/tests/playwright/fixtures/auto-image.tsx
+++ b/tests/playwright/fixtures/auto-image.tsx
@@ -1,27 +1,7 @@
-import process from "node:process";
 import { Box, render } from "ink";
 import React from "react";
 import Image, { TerminalInfoProvider } from "../../../src";
-
-function parseArgs(args: string[]) {
-  const result: Record<string, boolean | string> = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2);
-
-      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-        result[key] = args[++i];
-      } else {
-        result[key] = true;
-      }
-    }
-  }
-
-  return result;
-}
+import { parseArgs } from "./utils.js";
 
 const parsed = parseArgs(process.argv.slice(2));
 const imagePath = (parsed.src as string) || "";

--- a/tests/playwright/fixtures/background-color.tsx
+++ b/tests/playwright/fixtures/background-color.tsx
@@ -1,27 +1,7 @@
-import process from "node:process";
 import { Box, render, Text } from "ink";
 import React, { useEffect, useState } from "react";
 import Image, { ImageProtocolName, TerminalInfoProvider } from "../../../src";
-
-function parseArgs(args: string[]) {
-  const result: Record<string, boolean | string> = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2);
-
-      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-        result[key] = args[++i];
-      } else {
-        result[key] = true;
-      }
-    }
-  }
-
-  return result;
-}
+import { parseArgs } from "./utils.js";
 
 const parsed = parseArgs(process.argv.slice(2));
 const imagePath = (parsed.src as string) || "";

--- a/tests/playwright/fixtures/box-border.tsx
+++ b/tests/playwright/fixtures/box-border.tsx
@@ -1,4 +1,3 @@
-import process from "node:process";
 import { Box, render, Text } from "ink";
 import React, { useEffect, useState } from "react";
 import Image, { ImageProtocolName, TerminalInfoProvider } from "../../../src";

--- a/tests/playwright/fixtures/percentage-size.tsx
+++ b/tests/playwright/fixtures/percentage-size.tsx
@@ -1,27 +1,7 @@
-import process from "node:process";
 import { Box, render, Text } from "ink";
 import React from "react";
 import Image, { ImageProtocolName, TerminalInfoProvider } from "../../../src";
-
-function parseArgs(args: string[]) {
-  const result: Record<string, boolean | string> = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2);
-
-      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-        result[key] = args[++i];
-      } else {
-        result[key] = true;
-      }
-    }
-  }
-
-  return result;
-}
+import { parseArgs } from "./utils.js";
 
 const parsed = parseArgs(process.argv.slice(2));
 const imagePath = (parsed.src as string) || "";

--- a/tests/playwright/fixtures/protocol-hint.tsx
+++ b/tests/playwright/fixtures/protocol-hint.tsx
@@ -1,0 +1,58 @@
+import process from "node:process";
+import { Box, render } from "ink";
+import React from "react";
+import type { ImageProtocolHint, ImageProtocolName } from "../../../src";
+import Image, { TerminalInfoProvider } from "../../../src";
+
+function parseArgs(args: string[]) {
+  const result: Record<string, boolean | string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+
+      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        result[key] = args[++i];
+      } else {
+        result[key] = true;
+      }
+    }
+  }
+
+  return result;
+}
+
+const parsed = parseArgs(process.argv.slice(2));
+const imagePath = (parsed.src as string) || "";
+const imageWidth = parsed.width ? parseInt(parsed.width as string, 10) : 4;
+const imageHeight = parsed.height ? parseInt(parsed.height as string, 10) : 2;
+
+function parseProtocol(
+  raw: string | undefined,
+): ImageProtocolName | ImageProtocolHint | undefined {
+  if (!raw) return undefined;
+  if (raw.startsWith("{")) return JSON.parse(raw) as ImageProtocolHint;
+  return raw as ImageProtocolName;
+}
+
+const protocol = parseProtocol(parsed.protocol as string | undefined);
+
+export function App() {
+  return (
+    <TerminalInfoProvider>
+      <Box flexDirection="row" width={80} height={24}>
+        <Image
+          src={imagePath}
+          width={imageWidth}
+          height={imageHeight}
+          protocol={protocol}
+          alt="Protocol hint test"
+        />
+      </Box>
+    </TerminalInfoProvider>
+  );
+}
+
+render(<App />);

--- a/tests/playwright/fixtures/protocol-hint.tsx
+++ b/tests/playwright/fixtures/protocol-hint.tsx
@@ -1,28 +1,8 @@
-import process from "node:process";
 import { Box, render } from "ink";
 import React from "react";
 import type { ImageProtocolHint, ImageProtocolName } from "../../../src";
 import Image, { TerminalInfoProvider } from "../../../src";
-
-function parseArgs(args: string[]) {
-  const result: Record<string, boolean | string> = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2);
-
-      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-        result[key] = args[++i];
-      } else {
-        result[key] = true;
-      }
-    }
-  }
-
-  return result;
-}
+import { parseArgs } from "./utils.js";
 
 const parsed = parseArgs(process.argv.slice(2));
 const imagePath = (parsed.src as string) || "";

--- a/tests/playwright/fixtures/simple-image.tsx
+++ b/tests/playwright/fixtures/simple-image.tsx
@@ -1,27 +1,7 @@
-import process from "node:process";
 import { Box, render, Text } from "ink";
 import React from "react";
 import Image, { ImageProtocolName, TerminalInfoProvider } from "../../../src";
-
-function parseArgs(args: string[]) {
-  const result: Record<string, boolean | string> = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2);
-
-      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-        result[key] = args[++i];
-      } else {
-        result[key] = true;
-      }
-    }
-  }
-
-  return result;
-}
+import { parseArgs } from "./utils.js";
 
 const parsed = parseArgs(process.argv.slice(2));
 const imagePath = (parsed.src as string) || "";

--- a/tests/playwright/fixtures/utils.ts
+++ b/tests/playwright/fixtures/utils.ts
@@ -1,0 +1,19 @@
+export function parseArgs(args: string[]) {
+  const result: Record<string, boolean | string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+
+      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        result[key] = args[++i];
+      } else {
+        result[key] = true;
+      }
+    }
+  }
+
+  return result;
+}

--- a/tests/playwright/fixtures/vertical-offset.tsx
+++ b/tests/playwright/fixtures/vertical-offset.tsx
@@ -1,27 +1,7 @@
-import process from "node:process";
 import { Box, render, Text } from "ink";
 import React from "react";
 import Image, { ImageProtocolName, TerminalInfoProvider } from "../../../src";
-
-function parseArgs(args: string[]) {
-  const result: Record<string, boolean | string> = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2);
-
-      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-        result[key] = args[++i];
-      } else {
-        result[key] = true;
-      }
-    }
-  }
-
-  return result;
-}
+import { parseArgs } from "./utils.js";
 
 const parsed = parseArgs(process.argv.slice(2));
 const imagePath = (parsed.src as string) || "";

--- a/tests/playwright/fixtures/visibility.tsx
+++ b/tests/playwright/fixtures/visibility.tsx
@@ -1,0 +1,76 @@
+import { Box, render, Text, useApp, useInput } from "ink";
+import React, { useState } from "react";
+import Image, {
+  ImageProtocolName,
+  TerminalInfoProvider,
+  type Visibility,
+  type VisibilityInfo,
+} from "../../../src";
+
+function parseArgs(args: string[]) {
+  const result: Record<string, boolean | string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+
+      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        result[key] = args[++i];
+      } else {
+        result[key] = true;
+      }
+    }
+  }
+
+  return result;
+}
+
+const parsed = parseArgs(process.argv.slice(2));
+const imagePath = (parsed.src as string) || "";
+const protocol = (parsed.protocol as ImageProtocolName) || undefined;
+const useCustomVisibility = parsed.useCustomVisibility === true;
+const appHeight = parseInt(parsed.appHeight as string, 10) || 10;
+
+const getVisibility = useCustomVisibility
+  ? (_: VisibilityInfo): Visibility => "partial"
+  : undefined;
+
+export function App() {
+  const [marginTop, setMarginTop] = useState(0);
+  const { exit } = useApp();
+  useInput((input, key) => {
+    if (input === "w" || key.upArrow) {
+      setMarginTop((prev) => prev - 1);
+    } else if (input === "s" || key.downArrow) {
+      setMarginTop((prev) => prev + 1);
+    }
+  });
+
+  return (
+    <TerminalInfoProvider>
+      <Box flexDirection="row">
+        <Box
+          flexDirection="column"
+          height={appHeight}
+          width={4}
+          overflow="hidden"
+        >
+          <Box marginTop={marginTop}>
+            <Image
+              src={imagePath}
+              width={4}
+              height={2}
+              protocol={protocol}
+              getVisibility={getVisibility}
+            />
+          </Box>
+        </Box>
+        <Text>__READY__</Text>
+      </Box>
+    </TerminalInfoProvider>
+  );
+}
+
+render(<App />);

--- a/tests/playwright/fixtures/visibility.tsx
+++ b/tests/playwright/fixtures/visibility.tsx
@@ -6,26 +6,7 @@ import Image, {
   type Visibility,
   type VisibilityInfo,
 } from "../../../src";
-
-function parseArgs(args: string[]) {
-  const result: Record<string, boolean | string> = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2);
-
-      if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-        result[key] = args[++i];
-      } else {
-        result[key] = true;
-      }
-    }
-  }
-
-  return result;
-}
+import { parseArgs } from "./utils.js";
 
 const parsed = parseArgs(process.argv.slice(2));
 const imagePath = (parsed.src as string) || "";

--- a/tests/playwright/image.test.ts
+++ b/tests/playwright/image.test.ts
@@ -415,3 +415,36 @@ test.describe("useVisibility", () => {
     expect(bufferOutput).toMatch(/^\u2584{4}__READY__\s*\n\u2584{4}\s*$/);
   });
 });
+
+test.describe("protocol hints", () => {
+  test("string protocol forces that protocol always", async ({ ctx }) => {
+    const ps = await runFixture(
+      "protocol-hint.tsx",
+      ["--src", "../../example/images/full.png", "--protocol", "ascii"],
+      ctx.terminalProxy,
+    );
+    await ps.waitForExit();
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    expect(bufferOutput).toMatch(
+      /^[A-Za-z0-9~`!@#$%^&*()\-_=+\\|[{\]}'";:/?.>,<]{4}\s*\n[A-Za-z0-9~`!@#$%^&*()\-_=+\\|[{\]}'";:/?.>,<]{4}\s*$/,
+    );
+  });
+
+  test("object hint uses the specified protocol for full visibility", async ({
+    ctx,
+  }) => {
+    const ps = await runFixture(
+      "protocol-hint.tsx",
+      [
+        "--src",
+        "../../example/images/full.png",
+        "--protocol",
+        JSON.stringify({ full: "halfBlock" }),
+      ],
+      ctx.terminalProxy,
+    );
+    await ps.waitForExit();
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    expect(bufferOutput).toMatch(/^\u2584{4}\s*\n\u2584{4}\s*$/);
+  });
+});

--- a/tests/playwright/image.test.ts
+++ b/tests/playwright/image.test.ts
@@ -235,10 +235,6 @@ const verticalOffsetAppHeightCases = [
 ];
 
 test.describe("vertical offset", () => {
-  // kitty is sometimes flaky for some mysterious reason
-  test.describe.configure({
-    retries: 2,
-  });
   for (const protocol of advancedImageProtocols) {
     for (const {
       label,
@@ -313,3 +309,109 @@ test.describe
       });
     }
   });
+
+test("renders with default sizing", async ({ ctx }) => {
+  const ps = await runFixture(
+    "auto-image.tsx",
+    ["--src", "../../example/images/full.png"],
+    ctx.terminalProxy,
+  );
+  await ps.waitForExit();
+  const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+  expect(bufferOutput.length).toBeGreaterThan(0);
+});
+
+test.describe("useVisibility", () => {
+  test("renders with graphical protocol when image is fully visible", async ({
+    ctx,
+  }) => {
+    const ps = await runFixture(
+      "visibility.tsx",
+      ["--src", "../../example/images/full.png", "--appHeight", "50"],
+      ctx.terminalProxy,
+    );
+    await ps.waitUntilReady();
+    await timeout(4000);
+    const cells = await ctx.terminalProxy.cellsContainGraphics(0, 0, 4, 2);
+    for (const cell of cells) {
+      await expect(
+        cell.hasGraphic,
+        `Cell (${cell.x}, ${cell.y}) should contain graphics`,
+      ).toBe(true);
+    }
+  });
+
+  test("falls back to text protocol when image is partially visible in waterfall CLI", async ({
+    ctx,
+  }) => {
+    const ps = await runFixture(
+      "visibility.tsx",
+      ["--src", "../../example/images/full.png", "--appHeight", "51"],
+      ctx.terminalProxy,
+    );
+    await ps.waitUntilReady();
+    await timeout(4000);
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    expect(bufferOutput).toMatch(/^\u2584{4}__READY__\s*\n\u2584{4}\s*$/);
+  });
+
+  test("falls back to text protocol when image is hidden in waterfall CLI", async ({
+    ctx,
+  }) => {
+    const ps = await runFixture(
+      "visibility.tsx",
+      ["--src", "../../example/images/full.png", "--appHeight", "52"],
+      ctx.terminalProxy,
+    );
+    await ps.waitUntilReady();
+    await timeout(4000);
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    expect(bufferOutput).toMatch(/^\u2584{4}__READY__\s*\n\u2584{4}\s*$/);
+  });
+
+  test("falls back to text protocol when image is partially visible in TUI", async ({
+    ctx,
+  }) => {
+    const ps = await runFixture(
+      "visibility.tsx",
+      ["--src", "../../example/images/full.png", "--appHeight", "2"],
+      ctx.terminalProxy,
+    );
+    await ps.waitUntilReady();
+    await timeout(4000);
+    await ps.write("w");
+    await timeout(1000);
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    // top part of image should be clipped
+    expect(bufferOutput).toMatch(/^\u2584{4}__READY__\s*$/);
+
+    for (let i = 0; i < 2; i++) {
+      await ps.write("s");
+      await timeout(100);
+    }
+    await timeout(1000);
+    const bufferOutput2 = await ctx.terminalProxy.getBufferAsString();
+    // Bottom half of image should be clipped
+    expect(bufferOutput2).toMatch(/^ {4}__READY__\s*\n\u2584{4}\s*$/);
+  });
+
+  test("respects custom getVisibility logic", async ({ ctx }) => {
+    const ps = await runFixture(
+      "visibility.tsx",
+      [
+        "--src",
+        "../../example/images/full.png",
+        "--appHeight",
+        "2",
+        "--useCustomVisibility",
+      ],
+      ctx.terminalProxy,
+    );
+    await ps.waitUntilReady();
+    await timeout(4000);
+    const bufferOutput = await ctx.terminalProxy.getBufferAsString();
+    // Default visibility would be "full" since image fits within terminal,
+    // but custom callback forces it to be treated as "partial", thus the text fallback is rendered instead
+    expect(bufferOutput).toMatch(/^\u2584{4}__READY__\s*\n\u2584{4}\s*$/);
+  });
+});

--- a/tests/playwright/terminal.ts
+++ b/tests/playwright/terminal.ts
@@ -265,6 +265,13 @@ class TerminalProxy {
       [await this.getTerm()],
     );
   }
+
+  async getRows(): Promise<number> {
+    return this._page.evaluate(
+      ([term]) => (term as Terminal).rows,
+      [await this.getTerm()],
+    );
+  }
 }
 
 interface TerminalColorInfo {
@@ -316,6 +323,7 @@ interface ExitStatus {
 }
 
 export interface TerminalProcess {
+  waitUntilReady: () => Promise<void>;
   write: (input: string) => Promise<void>;
   output: string;
   waitForExit: () => Promise<ExitStatus>;
@@ -350,15 +358,18 @@ export async function createTerminalProcess({
   };
 
   const cols = await terminalProxy.getCols();
+  const rows = await terminalProxy.getRows();
 
   const pty = spawn(file, args, {
     name: "xterm-256color",
-    cols: cols,
+    cols,
+    rows,
     cwd: __dirname,
     env,
   });
 
   const result = {
+    waitUntilReady: () => processReadyPromise,
     async write(input: string) {
       // Give TS and Ink time to start up and render UI
       await processReadyPromise;

--- a/tests/vitest/imageCache.test.ts
+++ b/tests/vitest/imageCache.test.ts
@@ -1,0 +1,145 @@
+import { Jimp } from "jimp";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchImage } from "../../src/utils/image.js";
+import {
+  clearImageCache,
+  getCachedImage,
+  getCacheSize,
+  setCachedImage,
+} from "../../src/utils/imageCache.js";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+
+const SAMPLE = `${__dirname}../../example/images/full.png`;
+
+function makeImage(color = 0xff0000ff): Jimp {
+  return new Jimp({ width: 4, height: 4, color });
+}
+
+describe("imageCache", () => {
+  beforeEach(() => {
+    clearImageCache();
+  });
+
+  it("caches images", async () => {
+    expect(getCacheSize()).toBe(0);
+    const img = makeImage();
+    setCachedImage("test-key", img);
+    expect(getCacheSize()).toBe(1);
+    expect(getCachedImage("test-key")?.bitmap.data).toEqual(img.bitmap.data);
+  });
+
+  it("cache is immutable", async () => {
+    const image = makeImage();
+    setCachedImage("test-key", image);
+
+    const hit1 = getCachedImage("test-key");
+    const hit2 = getCachedImage("test-key");
+
+    expect(hit1?.bitmap.data).not.toBe(hit2?.bitmap.data);
+    expect(hit1?.bitmap.data).toEqual(hit2?.bitmap.data);
+  });
+
+  it("clear empties the cache", async () => {
+    setCachedImage("a", makeImage());
+    setCachedImage("b", makeImage());
+    expect(getCacheSize()).toBe(2);
+
+    clearImageCache();
+    expect(getCacheSize()).toBe(0);
+    expect(getCachedImage("a")).toBeUndefined();
+  });
+
+  it("evicts least recently used entries when full", async () => {
+    for (let i = 0; i < 12; i++) {
+      setCachedImage(`img-${i}`, makeImage());
+    }
+
+    expect(getCachedImage("img-0")).toBeUndefined();
+    expect(getCachedImage("img-1")).toBeUndefined();
+    for (let i = 2; i < 12; i++) {
+      expect(getCachedImage(`img-${i}`)).toBeDefined();
+    }
+  });
+
+  it("most-recently-used entry survives eviction", async () => {
+    for (let i = 0; i < 10; i++) {
+      setCachedImage(`img-${i}`, makeImage());
+    }
+
+    getCachedImage("img-0");
+
+    setCachedImage("overflow", makeImage());
+
+    expect(getCachedImage("img-0")).toBeDefined();
+    expect(getCachedImage("img-1")).toBeUndefined();
+  });
+
+  describe("environment variables", () => {
+    afterAll(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+
+    it("defaults to 10 entries", async () => {
+      vi.stubEnv("INK_PICTURE_CACHE_SIZE", undefined);
+      const mod = await import("../../src/utils/imageCache.js");
+      expect(mod.getCacheSize()).toBe(0);
+
+      for (let i = 0; i < 12; i++) {
+        mod.setCachedImage(`img-${i}`, makeImage());
+      }
+
+      expect(mod.getCacheSize()).toBe(10);
+
+      mod.clearImageCache();
+    });
+
+    it("INK_PICTURE_CACHE_SIZE=0 disables the cache", async () => {
+      vi.stubEnv("INK_PICTURE_CACHE_SIZE", "0");
+      vi.resetModules();
+
+      const mod = await import("../../src/utils/imageCache.js");
+      expect(mod.getCacheSize()).toBe(0);
+
+      mod.setCachedImage("test", makeImage());
+      expect(mod.getCacheSize()).toBe(0);
+    });
+
+    it("INK_PICTURE_CACHE_SIZE sets the max entries", async () => {
+      vi.stubEnv("INK_PICTURE_CACHE_SIZE", "3");
+      vi.resetModules();
+
+      const mod = await import("../../src/utils/imageCache.js");
+
+      for (let i = 0; i < 5; i++) {
+        mod.setCachedImage(`img-${i}`, makeImage());
+      }
+
+      expect(mod.getCacheSize()).toBe(3);
+
+      expect(mod.getCachedImage("img-0")).toBeUndefined();
+      expect(mod.getCachedImage("img-1")).toBeUndefined();
+      expect(mod.getCachedImage("img-2")).toBeDefined();
+
+      mod.clearImageCache();
+    });
+
+    it("INK_PICTURE_CACHE_SIZE defaults to 10 for invalid values", async () => {
+      for (const value of ["invalid", "-1"]) {
+        vi.stubEnv("INK_PICTURE_CACHE_SIZE", value);
+        vi.resetModules();
+
+        const mod = await import("../../src/utils/imageCache.js");
+
+        for (let i = 0; i < 12; i++) {
+          mod.setCachedImage(`img-${i}`, makeImage());
+        }
+
+        expect(mod.getCacheSize()).toBe(10);
+
+        mod.clearImageCache();
+      }
+    });
+  });
+});

--- a/tests/vitest/renderers/ascii.test.ts
+++ b/tests/vitest/renderers/ascii.test.ts
@@ -1,0 +1,55 @@
+import chalk from "chalk";
+import { beforeAll, describe, expect, it } from "vitest";
+import { renderAscii } from "../../../src/renderers/ascii.js";
+import { makePixelData, solidColor } from "./helpers.js";
+
+beforeAll(() => {
+  chalk.level = 3;
+});
+
+describe("renderAscii", () => {
+  it("produces correct dimensions", () => {
+    const pixels = makePixelData(4, 2, solidColor(128, 128, 128));
+    const result = renderAscii(pixels, { colored: false });
+
+    const lines = result.split("\n");
+    expect(lines.length).toBe(2);
+    expect(lines[0].length).toBe(4);
+    expect(lines[1].length).toBe(4);
+  });
+
+  it("maps white (255,255,255,255) to the darkest character ($)", () => {
+    const pixels = makePixelData(1, 1, solidColor(255, 255, 255, 255));
+    const result = renderAscii(pixels, { colored: false });
+
+    expect(result[0]).toBe("$");
+  });
+
+  it("maps transparent-black (0,0,0,0) to the lightest character (space)", () => {
+    const pixels = makePixelData(1, 1, solidColor(0, 0, 0, 0));
+    const result = renderAscii(pixels, { colored: false });
+
+    expect(result[0]).toBe(" ");
+  });
+
+  it("produces ANSI color codes when colored is true", () => {
+    const pixels = makePixelData(2, 1, solidColor(255, 0, 0, 255));
+    const result = renderAscii(pixels, { colored: true });
+
+    expect(result).toContain("\x1b[");
+  });
+
+  it("does not produce ANSI color codes when colored is false", () => {
+    const pixels = makePixelData(2, 1, solidColor(255, 0, 0, 255));
+    const result = renderAscii(pixels, { colored: false });
+
+    expect(result).not.toContain("\x1b[");
+  });
+
+  it("handles 1x1 minimum image", () => {
+    const pixels = makePixelData(1, 1, solidColor(100, 100, 100));
+    const result = renderAscii(pixels, { colored: false });
+
+    expect(result).toMatch(/^.$/);
+  });
+});

--- a/tests/vitest/renderers/braille.test.ts
+++ b/tests/vitest/renderers/braille.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { renderBraille } from "../../../src/renderers/braille.js";
+import { makePixelData, solidColor } from "./helpers.js";
+
+describe("renderBraille", () => {
+  it("produces correct dimensions", () => {
+    const pixels = makePixelData(2, 4, solidColor(128, 128, 128));
+    const result = renderBraille(pixels);
+
+    const lines = result.split("\n");
+    expect(lines.length).toBe(1);
+    expect(lines[0].length).toBe(1);
+  });
+
+  it("all-white pixels produce the braille dots 12345678", () => {
+    const pixels = makePixelData(2, 4, solidColor(255, 255, 255, 255));
+    const result = renderBraille(pixels);
+
+    expect(result[0]).toBe("\u28ff");
+  });
+
+  it("all-black pixels produce empty braille char", () => {
+    const pixels = makePixelData(2, 4, solidColor(0, 0, 0, 255));
+    const result = renderBraille(pixels);
+
+    expect(result[0]).toBe("\u2800");
+  });
+
+  it("handles transparent pixels as white", () => {
+    const pixels = makePixelData(2, 4, solidColor(0, 0, 0, 0));
+    const result = renderBraille(pixels);
+
+    expect(result[0]).toBe("\u28ff");
+  });
+
+  it("handles RGB data without alpha", () => {
+    const data = Buffer.alloc(2 * 4 * 3);
+    for (let i = 0; i < data.length; i += 3) {
+      data[i] = 255;
+      data[i + 1] = 255;
+      data[i + 2] = 255;
+    }
+    const pixels = {
+      data,
+      info: { width: 2, height: 4, channels: 3 },
+    };
+    const result = renderBraille(pixels);
+
+    expect(result[0]).toBe("\u28ff");
+  });
+
+  it("handles odd-sized images", () => {
+    const pixels = makePixelData(3, 5, solidColor(255, 255, 255, 255));
+    const result = renderBraille(pixels);
+
+    const lines = result.split("\n");
+    expect(lines.length).toBe(1);
+    expect(lines[0].length).toBe(1);
+  });
+
+  it("handles 1x1 minimum image", () => {
+    const pixels = makePixelData(1, 1, solidColor(255, 255, 255));
+    const result = renderBraille(pixels);
+
+    expect(result.length).toBe(0);
+  });
+});

--- a/tests/vitest/renderers/halfBlock.test.ts
+++ b/tests/vitest/renderers/halfBlock.test.ts
@@ -1,0 +1,62 @@
+import { stripVTControlCharacters } from "node:util";
+import chalk from "chalk";
+import { beforeAll, describe, expect, it } from "vitest";
+import { renderHalfBlock } from "../../../src/renderers/halfBlock.js";
+import { makePixelData, solidColor } from "./helpers.js";
+
+beforeAll(() => {
+  chalk.level = 3;
+});
+
+describe("renderHalfBlock", () => {
+  it("produces correct dimensions", () => {
+    const pixels = makePixelData(4, 2, solidColor(100, 100, 100));
+    const result = renderHalfBlock(pixels);
+
+    const lines = stripVTControlCharacters(result).split("\n");
+    expect(lines.length).toBe(1);
+    expect(lines[0].length).toBe(4);
+  });
+
+  it("produces correct dimensions for larger image", () => {
+    const pixels = makePixelData(16, 16, solidColor(100, 100, 100));
+    const result = renderHalfBlock(pixels);
+
+    const lines = stripVTControlCharacters(result).split("\n");
+    expect(lines.length).toBe(8);
+    expect(lines[0].length).toBe(16);
+    expect(lines[7].length).toBe(16);
+  });
+
+  it("contains ANSI color codes", () => {
+    const pixels = makePixelData(2, 2, solidColor(255, 0, 0, 255));
+    const result = renderHalfBlock(pixels);
+
+    expect(result).toContain("\x1b[");
+  });
+
+  it("handles 3-channel data (no alpha)", () => {
+    const data = Buffer.alloc(1 * 2 * 3);
+    data[0] = 255;
+    data[1] = 0;
+    data[2] = 0;
+    data[3] = 0;
+    data[4] = 0;
+    data[5] = 255;
+    const pixels = {
+      data,
+      info: { width: 1, height: 2, channels: 3 },
+    };
+    const result = renderHalfBlock(pixels);
+
+    expect(result).toContain("\u2584");
+    expect(result).toContain("\x1b[");
+  });
+
+  it("handles 1x1 pixel image", () => {
+    const pixels = makePixelData(1, 1, solidColor(0, 255, 0));
+    const result = renderHalfBlock(pixels);
+
+    expect(result.length).toBe(0);
+  });
+});

--- a/tests/vitest/renderers/helpers.ts
+++ b/tests/vitest/renderers/helpers.ts
@@ -1,0 +1,67 @@
+import { Jimp } from "jimp";
+import type { PixelData } from "../../../src/renderers/types.js";
+
+export function makePixelData(
+  width: number,
+  height: number,
+  fillColor: (x: number, y: number) => [number, number, number, number],
+): PixelData {
+  const channels = 4;
+  const data = Buffer.alloc(width * height * channels);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b, a] = fillColor(x, y);
+      const i = (y * width + x) * channels;
+      data[i] = r;
+      data[i + 1] = g;
+      data[i + 2] = b;
+      data[i + 3] = a;
+    }
+  }
+
+  return {
+    data,
+    info: { width, height, channels },
+  };
+}
+
+export function solidColor(
+  r: number,
+  g: number,
+  b: number,
+  a = 255,
+): (x: number, y: number) => [number, number, number, number] {
+  return () => [r, g, b, a];
+}
+
+export function checkerboard(
+  size: number,
+): (x: number, y: number) => [number, number, number, number] {
+  return (x, y) => {
+    const on = Math.floor(x / size) % 2 === Math.floor(y / size) % 2;
+    return on ? [255, 255, 255, 255] : [0, 0, 0, 255];
+  };
+}
+
+export function verticalGradient(
+  height: number,
+): (x: number, y: number) => [number, number, number, number] {
+  return (_x, y) => {
+    const v = Math.round((y / (height - 1)) * 255);
+    return [v, v, v, 255];
+  };
+}
+
+export async function jimpToPixelData(
+  image: Awaited<ReturnType<typeof Jimp.read>>,
+): Promise<PixelData> {
+  return {
+    data: image.bitmap.data,
+    info: {
+      width: image.bitmap.width,
+      height: image.bitmap.height,
+      channels: 4,
+    },
+  };
+}

--- a/tests/vitest/renderers/iterm2.test.ts
+++ b/tests/vitest/renderers/iterm2.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { renderITerm2 } from "../../../src/renderers/iterm2.js";
+
+describe("renderITerm2", () => {
+  it("produces valid iTerm2 escape sequence", () => {
+    const png = {
+      data: Buffer.from("fake-png-data"),
+      info: { width: 100, height: 200 },
+    };
+    const result = renderITerm2(png, { width: 100, height: 200 });
+
+    expect(result).toContain("\x1b]1337;File=");
+    expect(result).toContain(`size=${png.data.length}`);
+    expect(result).toContain("width=100px");
+    expect(result).toContain("height=200px");
+    expect(result).toContain("preserveAspectRatio=1");
+    expect(result).toContain("inline=1:");
+    expect(result).toContain(png.data.toString("base64"));
+    expect(result).toContain("\x07");
+  });
+});

--- a/tests/vitest/renderers/kitty.test.ts
+++ b/tests/vitest/renderers/kitty.test.ts
@@ -81,13 +81,30 @@ describe("makeKittyPlacement", () => {
 });
 
 describe("makeKittyDeletion", () => {
-  it("produces correct deletion escape sequence", () => {
+  it("produces correct deletion escape sequence (delete image data)", () => {
     const result = makeKittyDeletion(25);
 
     expect(result).toContain("a=d");
     expect(result).toContain("d=I");
     expect(result).toContain("i=25");
+    expect(result).not.toContain("p=");
     expect(result.startsWith("\x1b_G")).toBe(true);
     expect(result.endsWith("\x1b\\")).toBe(true);
+  });
+
+  it("produces correct placement deletion escape sequence", () => {
+    const result = makeKittyDeletion(42, 1);
+
+    expect(result).toContain("a=d");
+    expect(result).toContain("d=i");
+    expect(result).toContain("p=1");
+    expect(result).toContain("i=42");
+    expect(result.startsWith("\x1b_G")).toBe(true);
+    expect(result.endsWith("\x1b\\")).toBe(true);
+  });
+
+  it("uses provided placement ID for placement deletion", () => {
+    const result = makeKittyDeletion(10, 7);
+    expect(result).toContain("p=7");
   });
 });

--- a/tests/vitest/renderers/kitty.test.ts
+++ b/tests/vitest/renderers/kitty.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeKittyDeletion,
+  makeKittyPlacement,
+  makeKittyTransmitChunks,
+} from "../../../src/renderers/kitty.js";
+
+describe("makeKittyTransmitChunks", () => {
+  it("produces a single chunk for small data", () => {
+    const smallData = Buffer.from("AAA").toString("base64");
+    const chunks = makeKittyTransmitChunks(1, smallData);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain(`i=1`);
+    expect(chunks[0]).toContain("f=100,t=d");
+    expect(chunks[0]).toContain("m=0");
+    expect(chunks[0]).toContain("q=2");
+    expect(chunks[0]).toContain(smallData);
+    expect(chunks[0]).toContain("\x1b_G");
+    expect(chunks[0]).toContain("\x1b\\");
+  });
+
+  it("produces multiple chunks for large data", () => {
+    const chunkSize = 4096;
+    const largeData = "A".repeat(chunkSize * 2 + 100);
+
+    const chunks = makeKittyTransmitChunks(42, largeData);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+
+    expect(chunks[0]).toContain("f=100,t=d");
+    expect(chunks[0]).toContain("i=42");
+    expect(chunks[0]).toContain("m=1");
+
+    for (let i = 1; i < chunks.length - 1; i++) {
+      expect(chunks[i]).toContain("m=1");
+      expect(chunks[i]).not.toContain("f=100");
+      expect(chunks[i]).not.toContain("t=d");
+    }
+
+    expect(chunks[chunks.length - 1]).toContain("m=0");
+  });
+
+  it("uses a custom chunk size", () => {
+    const smallData = "A".repeat(50);
+    const chunks = makeKittyTransmitChunks(1, smallData, 10);
+
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  it("handles exact chunk size boundary", () => {
+    const chunkSize = 4096;
+    const exactData = "A".repeat(chunkSize);
+
+    const chunks = makeKittyTransmitChunks(1, exactData, chunkSize);
+
+    // Should be a single chunk since data fits exactly
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain("m=0");
+  });
+});
+
+describe("makeKittyPlacement", () => {
+  it("produces correct placement escape sequence with defaults", () => {
+    const result = makeKittyPlacement(15);
+
+    expect(result).toContain("a=p");
+    expect(result).toContain("i=15");
+    expect(result).toContain("p=1");
+    expect(result).toContain("C=1");
+    expect(result).toContain("q=2");
+    expect(result.startsWith("\x1b_G")).toBe(true);
+    expect(result.endsWith("\x1b\\")).toBe(true);
+  });
+
+  it("uses provided placement ID", () => {
+    const result = makeKittyPlacement(20, 5);
+
+    expect(result).toContain("p=5");
+  });
+});
+
+describe("makeKittyDeletion", () => {
+  it("produces correct deletion escape sequence", () => {
+    const result = makeKittyDeletion(25);
+
+    expect(result).toContain("a=d");
+    expect(result).toContain("d=I");
+    expect(result).toContain("i=25");
+    expect(result.startsWith("\x1b_G")).toBe(true);
+    expect(result.endsWith("\x1b\\")).toBe(true);
+  });
+});

--- a/tests/vitest/renderers/sixel.test.ts
+++ b/tests/vitest/renderers/sixel.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { renderSixel } from "../../../src/renderers/sixel.js";
+import { makePixelData, solidColor } from "./helpers.js";
+
+describe("renderSixel", () => {
+  it("produces a non-empty string", () => {
+    const pixels = makePixelData(4, 4, solidColor(255, 0, 0, 255));
+    const result = renderSixel(pixels);
+
+    expect(result).toBeDefined();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("handles transparent pixels", () => {
+    const pixels = makePixelData(2, 2, solidColor(255, 255, 255, 0));
+    const result = renderSixel(pixels);
+
+    expect(result).toBeDefined();
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/vitest/useVisibility.test.ts
+++ b/tests/vitest/useVisibility.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { Position } from "../../src/hooks/usePosition.js";
+import type { VisibilityInfo } from "../../src/hooks/useVisibility.js";
+import { defaultVisibility } from "../../src/hooks/useVisibility.js";
+
+function makePosition(overrides: Partial<Position> = {}): Position {
+  return {
+    col: 10,
+    row: 5,
+    width: 40,
+    height: 20,
+    appWidth: 80,
+    appHeight: 25,
+    ...overrides,
+  };
+}
+
+describe("defaultVisibility", () => {
+  describe("full visibility", () => {
+    it("returns full when image is entirely within viewport", () => {
+      const pos = makePosition({ row: 5, height: 20, appHeight: 25 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("full");
+    });
+
+    it("returns full when app is taller than terminal but image is visible", () => {
+      const pos = makePosition({ row: 40, height: 10, appHeight: 80 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("full");
+    });
+  });
+
+  describe("partial visibility", () => {
+    it("returns partial when image top is clipped by viewport", () => {
+      // Terminal: 50, app: 80. Image at row 15, height 30.
+      // viewportStartRow = 50 - 80 + 15 = -15 (top clipped)
+      const pos = makePosition({ row: 15, height: 30, appHeight: 80 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("partial");
+    });
+
+    it("returns partial when image bottom extends past viewport", () => {
+      // Terminal: 50, app: 25. Image at row 20, height 10.
+      // viewportStartRow = 50 - 25 + 20 = 45
+      // viewportEndRow = 55 (> 50)
+      const pos = makePosition({ row: 20, height: 10, appHeight: 25 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("partial");
+    });
+
+    it("returns partial when image extends beyond right viewport edge", () => {
+      // col=90, width=20 → endCol=110 > terminalWidth=100, but within app bounds
+      const pos = makePosition({ col: 90, width: 20, appWidth: 120 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("partial");
+    });
+
+    it("returns hidden when image starts beyond app right edge", () => {
+      const pos = makePosition({ col: 90, width: 10, appWidth: 80 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("hidden");
+    });
+  });
+
+  describe("hidden visibility", () => {
+    it("returns hidden when image is entirely above viewport", () => {
+      // Terminal: 50, app: 80. Image at row 0, height 10.
+      // viewportStartRow = 50 - 80 + 0 = -30
+      // viewportEndRow = -20 (entirely above)
+      const pos = makePosition({ row: 0, height: 10, appHeight: 80 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("hidden");
+    });
+
+    it("returns hidden when image is entirely below viewport", () => {
+      // Terminal: 50, app: 25. Image at row 40, height 10.
+      // viewportStartRow = 50 - 25 + 40 = 65 (> 50)
+      const pos = makePosition({ row: 40, height: 10, appHeight: 25 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("hidden");
+    });
+
+    it("returns hidden when image is entirely to the right", () => {
+      const pos = makePosition({ col: 110, width: 10 });
+      expect(defaultVisibility(pos, 50, 100)).toBe("hidden");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR overhauls the internal architecture of `ink-picture`, extracting duplicated rendering logic from the six protocol-specific image components into shared hooks and pure renderer functions. It adds an LRU image cache, smart protocol fallback based on image visibility (off-screen / partially visible), and a comprehensive test suite.

## New features

### Dynamic protocol switching and `getVisibility` system

In a TUI, images may be fully visible in the terminal viewport, partially obstructed by viewport edges or other components, or completely out-of-bounds or hidden. Partially-visible and hidden images cannot be rendered with a graphical protocol because:

- Terminal escape sequences do not allow the cursor to move beyond the visible viewport buffer into the history buffer to write graphical escape sequences
- Rendering cropped images to fit available space require re-encoding image display escape sequences which introduces significant complexity

A visibility detection system is introduced, classifying each image into three states: `"full" | "partial" | "hidden"`. By default, `full` images will be rendered with a graphical protocol if available, and `Image` falls back to a text-based protocol if the image becomes `partial` or `hidden` in order to render a preview.

The `protocol` prop in `Image` now accepts either a `string` or a `ProtocolhHint`:
- `string`: always uses this protocol, and turns off dynamic protocol switching behavior
- `ProtocolHint`: specifies which protocol to use for each visibility state, e.g. `{ full: "kitty", partial: "halfBlock" }`; unspecified visibility states follow default dynamic switching behavior
- `undefined`: dynamic protocol switching behavior

The `useVisibility` hook determines an image's visibility by checking it against terminal viewport bounds. For precise control,  e.g. headers or footers which would hide the image, downstream developers can pass a custom `getVisibility` callback prop to `Image` which receives the image's absolute position information and returns a visibility value.

### LRU image cache
- Cache for image fetching layer for performance enhancement, with key-value pairs of `{src: imageData}`
- Only URLs and local file paths are cached while raw buffer image data is not
- LRU eviction policy with immutability (clones on get/set so image data can be operated on)
- Exported utilities: `getCachedImage`, `setCachedImage`, `clearImageCache`, `getCacheSize`
- Configurable via `INK_PICTURE_CACHE_SIZE` env var (default: 10, disabled by setting to `0`)

## Bug fixes

- Delete kitty out-of-bounds image placements when they scroll off screen. Images deleted this way still have their data persisted in the terminal's memory for re-placement when they become fully visible again. Image data is fully cleared when the component unmounts
- Added active 16ms polling interval to `usePosition` in order to detect layout changes, e.g. from parent/sibling re-renders, where React would otherwise skip re-rendering the component and re-running `usePosition`
- Add missing `.js` extensions in import statements

## Architecture

Refactored from main `<Image>` export + 6 protocol renderers to a three-tier architecture:

### Tier 1: low-level rendering logic

These are standalone, pure functions operating on image data that don't require React or a terminal environment.
- `renderAscii`, `renderBraille`, `renderHalfBlock`: produce strings of terminal escape sequences
- `makeKittyTransmitChunks`, `makeKittyPlacement`, `makeKittyDeletion`: kitty protocol primitives
- `renderSixel`, `renderITerm2`: sixel and iTerm2 escape sequence generation

### Tier 2: Individual protocol image components

The 6 original `*Image` components but refactored to be DRY and use the tier 1 renderers.

#### Shared hooks

Previously each protocol component independently managed image loading, sizing, positioning, and cleanup. Now shared across all six:

| Hook | Purpose |
|------|---------|
| `useImage` | Unified async image loading with cache integration |
| `useMeasuredSize` | Resolves percentage-based width/height via `measureElement` |
| `usePosition` | Tracks absolute terminal cell position; now polls at ~60fps for app layout changes |
| `useDirectRenderer` | Shared direct-to-stdout rendering with position-aware cleanup for sixel and IIP |

#### `ImageBox` component

Extracted the loading spinner, error state, and alt-text fallback rendering into a single shared `<ImageBox>` component, replacing duplicated JSX in every protocol component.

### Tier 3: the smart `Image` component

Main export with automatic protocol selection, visibility-based protocol switching, and screen-reader accessibility integration. Designed as a OOTB drop-in optimized component similar to Next.js's `<Image />`.

### New exports

- `useVisibility`, `clearImageCache`, `getCachedImage`, `getCacheSize`, `setCachedImage`
- `ImageProtocolHint`, `GetVisibility`, `Visibility`, `VisibilityInfo` types

## Tests

- **Vitest** (8 new test files): `imageCache.test.ts`, `useVisibility.test.ts`, renderer tests for all 6 protocols
- **Playwright** (4 new fixture files): visibility tests (TUI scrolling, waterfall CLI overflow), protocol hint tests, auto-image tests
  - Centralized `parseArgs` fixture utility
  - Fixed `process.stdout.rows` not matching actual xterm.js terminal rows in test harness
  
## To-dos

- **Update readme with docs**: this will be done before release after all changes are stable