### PR TITLE
feat: Add objectFit prop and fix transparency bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,9 @@
+Read DEVELOPMENT.md for implementation decisions and explanations.
+
 After making non-trivial changes, always run linter and tests, and fix any issues that arise.
 Prefer using commands (`biome format`, `biome lint --fix`) over manual edits to fix formatting and lint issues.
 
-Add new tests after implementing new features. In generally:
+Add new tests after implementing new features. In general:
 
 - Tests that don't require the terminal interpreting escape sequences should go under `tests/vitest`
 - tests that require a full-fledged terminal environment should go under `tests/playwright`, which spins up a real xterm.js terminal to run tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -123,6 +123,29 @@ Alternative text displayed during image loading and error. It is also used in In
 <Image src="path/to/image.png" alt="a close-up shot of a red brick house" />
 ```
 
+#### `objectFit` (optional)
+
+type: `"fill" | "contain" | "cover"`
+
+default: `"fill"`
+
+Controls how the image is resized to fit the dimensions given by `width` and `height`.
+
+- `"fill"` (default): stretches the image to fill the entire box.
+- `"contain"`: preserves the image's aspect ratio and scales it to fit entirely inside the box. Empty space is centered around the image.
+- `"cover"`: preserves the image's aspect ratio and scales it to cover the entire box, cropping any overflow.
+
+```tsx
+// Stretch to fill (default)
+<Image src="path/to/image.png" width={20} height={10} />
+
+// Preserve aspect ratio and fit inside the box
+<Image src="path/to/image.png" width={20} height={10} objectFit="contain" />
+
+// Preserve aspect ratio and fill the box, cropping as needed
+<Image src="path/to/image.png" width={20} height={10} objectFit="cover" />
+```
+
 #### `protocol` (optional)
 
 type: `ImageProtocolName | ImageProtocolHint`

--- a/src/components/image/Ascii.tsx
+++ b/src/components/image/Ascii.tsx
@@ -9,7 +9,7 @@ import type { ImageProps } from "./protocol.js";
 
 function AsciiImage(props: ImageProps) {
   const terminalInfo = useTerminalInfo();
-  const { src, width, height, alt } = props;
+  const { src, width, height, alt, objectFit } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -21,6 +21,7 @@ function AsciiImage(props: ImageProps) {
     pixelWidth: resolvedWidth,
     pixelHeight: resolvedHeight,
     mode: "pixels",
+    objectFit,
   });
 
   const imageOutput = useMemo(() => {

--- a/src/components/image/Ascii.tsx
+++ b/src/components/image/Ascii.tsx
@@ -16,12 +16,18 @@ function AsciiImage(props: ImageProps) {
     height,
   );
 
+  const cellRatio =
+    terminalInfo?.cellHeight && terminalInfo.cellWidth
+      ? terminalInfo.cellHeight / terminalInfo.cellWidth
+      : 2;
+
   const { imageData, error } = useImage({
     src,
     pixelWidth: resolvedWidth,
     pixelHeight: resolvedHeight,
     mode: "pixels",
     objectFit,
+    cellRatio,
   });
 
   const imageOutput = useMemo(() => {

--- a/src/components/image/Braille.tsx
+++ b/src/components/image/Braille.tsx
@@ -7,7 +7,7 @@ import ImageBox from "../ImageBox.js";
 import type { ImageProps } from "./protocol.js";
 
 function BrailleImage(props: ImageProps) {
-  const { src, width, height, alt } = props;
+  const { src, width, height, alt, objectFit } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -19,6 +19,7 @@ function BrailleImage(props: ImageProps) {
     pixelWidth: resolvedWidth * 2,
     pixelHeight: resolvedHeight * 4,
     mode: "pixels",
+    objectFit,
   });
 
   const imageOutput = useMemo(() => {

--- a/src/components/image/HalfBlock.tsx
+++ b/src/components/image/HalfBlock.tsx
@@ -1,5 +1,6 @@
 import { Text } from "ink";
 import React, { useMemo } from "react";
+import useBackgroundColor from "../../hooks/useBackgroundColor.js";
 import { useImage } from "../../hooks/useImage.js";
 import { useMeasuredSize } from "../../hooks/useMeasuredSize.js";
 import { renderHalfBlock } from "../../renderers/halfBlock.js";
@@ -21,11 +22,12 @@ function HalfBlockImage(props: ImageProps) {
     mode: "pixels",
     objectFit,
   });
+  const inheritedBackgroundColor = useBackgroundColor(containerRef);
 
   const imageOutput = useMemo(() => {
     if (!imageData) return null;
-    return renderHalfBlock(imageData);
-  }, [imageData]);
+    return renderHalfBlock(imageData, { bgColor: inheritedBackgroundColor });
+  }, [imageData, inheritedBackgroundColor]);
 
   return (
     <ImageBox

--- a/src/components/image/HalfBlock.tsx
+++ b/src/components/image/HalfBlock.tsx
@@ -7,7 +7,7 @@ import ImageBox from "../ImageBox.js";
 import type { ImageProps } from "./protocol.js";
 
 function HalfBlockImage(props: ImageProps) {
-  const { src, width, height, alt } = props;
+  const { src, width, height, alt, objectFit } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -19,6 +19,7 @@ function HalfBlockImage(props: ImageProps) {
     pixelWidth: resolvedWidth,
     pixelHeight: resolvedHeight * 2,
     mode: "pixels",
+    objectFit,
   });
 
   const imageOutput = useMemo(() => {

--- a/src/components/image/ITerm2.tsx
+++ b/src/components/image/ITerm2.tsx
@@ -13,7 +13,7 @@ import type { ImageProps } from "./protocol.js";
 function ITerm2Image(props: ImageProps) {
   const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const { src, width, height, alt } = props;
+  const { src, width, height, alt, objectFit } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -31,6 +31,7 @@ function ITerm2Image(props: ImageProps) {
     pixelWidth,
     pixelHeight,
     mode: "png",
+    objectFit,
   });
 
   const imageOutput = useMemo(() => {

--- a/src/components/image/Kitty.tsx
+++ b/src/components/image/Kitty.tsx
@@ -18,7 +18,7 @@ import type { ImageProps } from "./protocol.js";
 function KittyImage(props: ImageProps) {
   const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const { src, width, height, alt } = props;
+  const { src, width, height, alt, objectFit } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -35,6 +35,7 @@ function KittyImage(props: ImageProps) {
     pixelWidth,
     pixelHeight,
     mode: "png",
+    objectFit,
   });
 
   const [imageId, setImageId] = useState<number | undefined>(undefined);

--- a/src/components/image/Sixel.tsx
+++ b/src/components/image/Sixel.tsx
@@ -13,7 +13,7 @@ import type { ImageProps } from "./protocol.js";
 function SixelImage(props: ImageProps) {
   const terminalInfo = useTerminalInfo();
   const { stdout } = useStdout();
-  const { src, width, height, alt } = props;
+  const { src, width, height, alt, objectFit } = props;
 
   const { containerRef, resolvedWidth, resolvedHeight } = useMeasuredSize(
     width,
@@ -31,6 +31,7 @@ function SixelImage(props: ImageProps) {
     pixelWidth,
     pixelHeight,
     mode: "pixels",
+    objectFit,
   });
 
   const imageOutput = useMemo(() => {

--- a/src/components/image/protocol.ts
+++ b/src/components/image/protocol.ts
@@ -13,6 +13,13 @@ export interface ImageProps {
   height: number | string;
   /** Alternative text displayed while loading or on error */
   alt?: string;
+  /**
+   * How the image should be resized to fit the given dimensions.
+   * - `"fill"` (default): stretch to fill the box.
+   * - `"contain"`: preserve aspect ratio and fit the whole image inside the box.
+   * - `"cover"`: preserve aspect ratio and cover the box, cropping overflow.
+   */
+  objectFit?: "fill" | "contain" | "cover";
 }
 
 /**

--- a/src/hooks/useImage.ts
+++ b/src/hooks/useImage.ts
@@ -15,6 +15,7 @@ export function useImage<T extends "pixels" | "png" = "pixels">(options: {
   pixelHeight: number;
   mode?: T;
   objectFit?: "fill" | "contain" | "cover";
+  cellRatio?: number;
 }): T extends "png"
   ? { imageData: PngData | undefined; error: boolean }
   : { imageData: PixelData | undefined; error: boolean } {
@@ -24,6 +25,7 @@ export function useImage<T extends "pixels" | "png" = "pixels">(options: {
     pixelHeight,
     mode = "pixels",
     objectFit = "fill",
+    cellRatio,
   } = options;
   const [imageData, setImageData] = useState<PngData | PixelData | undefined>(
     undefined,
@@ -55,7 +57,7 @@ export function useImage<T extends "pixels" | "png" = "pixels">(options: {
       }
 
       setError(false);
-      resizeImage(image, objectFit, pixelWidth, pixelHeight);
+      resizeImage(image, objectFit, pixelWidth, pixelHeight, cellRatio);
 
       if (mode === "png") {
         const result = await getPngBuffer(image);
@@ -75,7 +77,7 @@ export function useImage<T extends "pixels" | "png" = "pixels">(options: {
     return () => {
       cancelled = true;
     };
-  }, [src, pixelWidth, pixelHeight, mode, objectFit, cache]);
+  }, [src, pixelWidth, pixelHeight, mode, objectFit, cache, cellRatio]);
 
   return { imageData, error } as T extends "png"
     ? { imageData: PngData | undefined; error: boolean }

--- a/src/hooks/useImage.ts
+++ b/src/hooks/useImage.ts
@@ -2,17 +2,29 @@ import { type Jimp } from "jimp";
 import { useEffect, useState } from "react";
 import { useImageCache } from "../InkPictureProvider.js";
 import type { PixelData, PngData } from "../renderers/types.js";
-import { fetchImage, getPngBuffer, getRawPixels } from "../utils/image.js";
+import {
+  fetchImage,
+  getPngBuffer,
+  getRawPixels,
+  resizeImage,
+} from "../utils/image.js";
 
 export function useImage<T extends "pixels" | "png" = "pixels">(options: {
   src: Parameters<typeof Jimp.read>[0];
   pixelWidth: number;
   pixelHeight: number;
   mode?: T;
+  objectFit?: "fill" | "contain" | "cover";
 }): T extends "png"
   ? { imageData: PngData | undefined; error: boolean }
   : { imageData: PixelData | undefined; error: boolean } {
-  const { src, pixelWidth, pixelHeight, mode = "pixels" } = options;
+  const {
+    src,
+    pixelWidth,
+    pixelHeight,
+    mode = "pixels",
+    objectFit = "fill",
+  } = options;
   const [imageData, setImageData] = useState<PngData | PixelData | undefined>(
     undefined,
   );
@@ -43,7 +55,7 @@ export function useImage<T extends "pixels" | "png" = "pixels">(options: {
       }
 
       setError(false);
-      image.resize({ w: pixelWidth, h: pixelHeight });
+      resizeImage(image, objectFit, pixelWidth, pixelHeight);
 
       if (mode === "png") {
         const result = await getPngBuffer(image);
@@ -63,7 +75,7 @@ export function useImage<T extends "pixels" | "png" = "pixels">(options: {
     return () => {
       cancelled = true;
     };
-  }, [src, pixelWidth, pixelHeight, mode, cache]);
+  }, [src, pixelWidth, pixelHeight, mode, objectFit, cache]);
 
   return { imageData, error } as T extends "png"
     ? { imageData: PngData | undefined; error: boolean }

--- a/src/renderers/braille.ts
+++ b/src/renderers/braille.ts
@@ -63,6 +63,10 @@ function rgbaToBlackOrWhite({
   b: number;
   a: number;
 }) {
+  if (a === 0) {
+    return 0;
+  }
+
   const alpha = a / 255;
   const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
   const alphaAdjustedLuminance = luminance * alpha + 255 * (1 - alpha);

--- a/src/renderers/halfBlock.ts
+++ b/src/renderers/halfBlock.ts
@@ -1,9 +1,13 @@
 import chalk from "chalk";
+import bgColorize from "../utils/bgColorize.js";
 import type { PixelData } from "./types.js";
 
 const HALF_BLOCK = "\u2584";
 
-export function renderHalfBlock(pixels: PixelData): string {
+export function renderHalfBlock(
+  pixels: PixelData,
+  options: { bgColor?: string } = {},
+): string {
   const { data, info } = pixels;
   const { width, height, channels } = info;
 
@@ -24,7 +28,9 @@ export function renderHalfBlock(pixels: PixelData): string {
 
       result +=
         a === 0
-          ? chalk.reset(" ")
+          ? options.bgColor
+            ? bgColorize(" ", options.bgColor)
+            : chalk.reset(" ")
           : chalk.bgRgb(r, g, b).rgb(r2, g2, b2)(HALF_BLOCK);
     }
 

--- a/src/renderers/sixel.ts
+++ b/src/renderers/sixel.ts
@@ -1,8 +1,45 @@
-import { image2sixel } from "sixel";
+import { FINALIZER, introducer, sixelEncode } from "sixel";
+import { reduce } from "sixel/lib/Quantizer.js";
 import type { PixelData } from "./types.js";
 
 export function renderSixel(pixels: PixelData): string {
   const { data, info } = pixels;
-  const u8Data = new Uint8Array(data);
-  return image2sixel(u8Data, info.width, info.height);
+  const { width, height } = info;
+  const pixelCount = width * height;
+
+  const opaqueCopy = new Uint8Array(data.slice());
+  // Replace fully transparent pixels with opaque black pixels to avoid issues with the quantizer
+  for (let i = 0; i < pixelCount; i++) {
+    const offset = i * 4;
+    if (opaqueCopy[offset + 3] === 0) {
+      opaqueCopy[offset] = 0;
+      opaqueCopy[offset + 1] = 0;
+      opaqueCopy[offset + 2] = 0;
+      opaqueCopy[offset + 3] = 255;
+    }
+  }
+
+  const { indices, palette } = reduce(opaqueCopy, width, 256);
+
+  const quantOutput = new Uint8Array(pixelCount * 4);
+  const originalData = new Uint8Array(data.slice());
+  for (let i = 0; i < pixelCount; i++) {
+    const offset = i * 4;
+    if (originalData[offset + 3] === 0) {
+      quantOutput[offset] = 0;
+      quantOutput[offset + 1] = 0;
+      quantOutput[offset + 2] = 0;
+      quantOutput[offset + 3] = 0;
+    } else {
+      const color = palette[indices[i]];
+      quantOutput[offset] = color & 0xff;
+      quantOutput[offset + 1] = (color >> 8) & 0xff;
+      quantOutput[offset + 2] = (color >> 16) & 0xff;
+      quantOutput[offset + 3] = (color >> 24) & 0xff;
+    }
+  }
+
+  const sixelData = sixelEncode(quantOutput, width, height, palette);
+
+  return [introducer(1), sixelData, FINALIZER].join("");
 }

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -57,7 +57,15 @@ export function resizeImage(
   objectFit: "fill" | "contain" | "cover",
   width: number,
   height: number,
+  cellRatio?: number,
 ): void {
+  if (cellRatio !== undefined && cellRatio !== 1 && objectFit !== "fill") {
+    image.resize({
+      w: Math.round(image.bitmap.width * cellRatio),
+      h: image.bitmap.height,
+    });
+  }
+
   switch (objectFit) {
     case "contain":
       image.contain({ w: width, h: height });

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -52,65 +52,20 @@ export async function getPngBuffer(
   };
 }
 
-export function calculateImageSize({
-  maxWidth,
-  maxHeight,
-  originalAspectRatio,
-  specifiedWidth,
-  specifiedHeight,
-}: {
-  maxWidth: number;
-  maxHeight: number;
-  originalAspectRatio: number;
-  specifiedWidth?: number;
-  specifiedHeight?: number;
-}): { width: number; height: number } {
-  // Both width and height specified
-  if (specifiedWidth && specifiedHeight) {
-    const width = Math.min(specifiedWidth, maxWidth);
-    const height = Math.min(specifiedHeight, maxHeight);
-    return { width: Math.round(width), height: Math.round(height) };
+export function resizeImage(
+  image: JimpImage,
+  objectFit: "fill" | "contain" | "cover",
+  width: number,
+  height: number,
+): void {
+  switch (objectFit) {
+    case "contain":
+      image.contain({ w: width, h: height });
+      break;
+    case "cover":
+      image.cover({ w: width, h: height });
+      break;
+    default:
+      image.resize({ w: width, h: height });
   }
-
-  // Only width specified
-  if (specifiedWidth) {
-    let width = Math.min(specifiedWidth, maxWidth);
-    let height = width / originalAspectRatio;
-
-    if (height > maxHeight) {
-      height = maxHeight;
-      width = height * originalAspectRatio;
-    }
-
-    return { width: Math.round(width), height: Math.round(height) };
-  }
-
-  // Only height specified
-  if (specifiedHeight) {
-    let height = Math.min(specifiedHeight, maxHeight);
-    let width = height * originalAspectRatio;
-
-    if (width > maxWidth) {
-      width = maxWidth;
-      height = width / originalAspectRatio;
-    }
-
-    return { width: Math.round(width), height: Math.round(height) };
-  }
-
-  // No dimensions specified - scale to fit while maintaining aspect ratio
-  let height = maxHeight;
-  let width = height * originalAspectRatio;
-
-  if (width > maxWidth) {
-    width = maxWidth;
-    height = width / originalAspectRatio;
-  }
-
-  if (height > maxHeight) {
-    height = maxHeight;
-    width = height * originalAspectRatio;
-  }
-
-  return { width: Math.round(width), height: Math.round(height) };
 }

--- a/tests/vitest/renderers/braille.test.ts
+++ b/tests/vitest/renderers/braille.test.ts
@@ -26,7 +26,7 @@ describe("renderBraille", () => {
     expect(result[0]).toBe("\u2800");
   });
 
-  it("render transparent pixels as whitespace", () => {
+  it("renders transparent pixels as whitespace", () => {
     const pixels = makePixelData(2, 4, solidColor(0, 0, 0, 0));
     const result = renderBraille(pixels);
 

--- a/tests/vitest/renderers/braille.test.ts
+++ b/tests/vitest/renderers/braille.test.ts
@@ -26,11 +26,11 @@ describe("renderBraille", () => {
     expect(result[0]).toBe("\u2800");
   });
 
-  it("handles transparent pixels as white", () => {
+  it("render transparent pixels as whitespace", () => {
     const pixels = makePixelData(2, 4, solidColor(0, 0, 0, 0));
     const result = renderBraille(pixels);
 
-    expect(result[0]).toBe("\u28ff");
+    expect(result[0]).toBe("\u2800");
   });
 
   it("handles RGB data without alpha", () => {


### PR DESCRIPTION
## Summary

Adds an `objectFit` prop (mirroring CSS `object-fit`) to control how images are resized into their container. Also fixes transparency rendering across text-based and Sixel protocols.

## New Features

- **`objectFit` prop**: Works across all image protocols:
  - `"fill"` (default, stretches to fill)
  - `"contain"` (preserve aspect ratio, fit inside)
  - `"cover"` (preserve aspect ratio, crop overflow)

## Bug Fixes

- **HalfBlock background color inheritance**: detects Ink's inherited box background color and uses it for transparent areas instead of a hardcoded reset, which uses the terminal's background color.
- **Sixel transparency**: rewrote the Sixel renderer to use `sixelEncode` + `reduce` directly instead of `image2sixel`. Transparent pixels are now properly handled during quantization and the alpha channel is preserved in the output.
- **Braille transparency**: fully transparent pixels (`a === 0`) now render as empty cells instead of full cells (white).
- **Contain/cover resizing for text-based protocols**: fixed `contain`/`cover` resizing in `useImage` to accept a `cellRatio` parameter so that non-square terminal cells are compensated for before aspect-ratio calculations.

## Internal Changes / Chores

- Replaced the old `calculateImageSize` utility with a simpler `resizeImage` function that delegates to Jimp's built-in `contain`/`cover`/`resize` methods.
- Update docs for the new `objectFit` prop.
- Symlinked `CLAUDE.md` → `AGENTS.md`.
